### PR TITLE
Add missing variable defaults for 'rhel9cis_pam_faillock'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -582,6 +582,9 @@ rhel9cis_pam_password:
     minclass: 4
 
 rhel9cis_pam_faillock:
+    attempts: 5
+    unlock_time: 900
+    fail_for_root: no
     remember: 5
 
 # UID settings for interactive users

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -584,6 +584,7 @@ rhel9cis_pam_password:
 rhel9cis_pam_faillock:
     unlock_time: 900
     deny: 5
+    remember: 5
 
 # UID settings for interactive users
 # These are discovered via logins.def if set true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -582,10 +582,8 @@ rhel9cis_pam_password:
     minclass: 4
 
 rhel9cis_pam_faillock:
-    attempts: 5
     unlock_time: 900
-    fail_for_root: no
-    remember: 5
+    deny: 5
 
 # UID settings for interactive users
 # These are discovered via logins.def if set true


### PR DESCRIPTION
Some required variables in the 'rhel9cis_pam_faillock' dict were missing default values. I copied the defaults from the RHEL8-CIS playbook