### PR TITLE
Fix UMASK hardening

### DIFF
--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -91,13 +91,13 @@
         replace:
             path: /etc/bashrc
             regexp: '^(?i)(\s+UMASK|UMASK)\s0[0-2][0-6]'
-            replace: 'UMASK 027'
+            replace: '\1 027'
 
       - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Set umask for /etc/profile"
         replace:
             path: /etc/profile
             regexp: '^(?i)(\s+UMASK|UMASK)\s0[0-2][0-6]'
-            replace: 'UMASK 027'
+            replace: '\1 027'
   when:
       - rhel9cis_rule_5_6_5
   tags:


### PR DESCRIPTION
Updated regex replacements in bashrc umask hardening. Hard-coded replacement with `UMASK` results in runtime failure because `UMASK` (all caps) does not exist. Also, whitespace was not being preserved. 