### PR TITLE
Legacy os check removal

### DIFF
--- a/tasks/check_prereqs.yml
+++ b/tasks/check_prereqs.yml
@@ -1,38 +1,8 @@
 ---
 
-- name: "PREREQ | Add the required packages | Python 3"
-  block:
-      - name: Check if python36-rpm package installed
-        shell: rpm -q python36-rpm
-        args:
-            warn: false
-        failed_when: ( python36_rpm_present.rc not in [ 0, 1 ] )
-        changed_when: false
-        register: python36_rpm_present
-
-      - name: Add the EPEL repository required for the python36-rpm pkg
-        package:
-            name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-            state: present
-        register: epel_installed
-        when:
-            - python36_rpm_present.rc != '0'
-
-      - name: "PREREQ | Check required packages installed | Python3 "
-        package:
-            name: "{{ item }}"
-            state: present
-        register: python3reqs_installed
-        loop:
-            - python36-rpm
-            - libselinux-python3
-
-      - name: Disable Epel repo if installed earlier
-        shell: yum-config-manager disable epel
-        args:
-            warn: false
-        when: epel_installed.changed
+- name: "PREREQ | If required install libselinux package to manage file changes."
+  package:
+      name: libselinux-python3
+      state: present
   when:
-      - ( ansible_python.version.major == 3  and ansible_python.version.minor == 6 )
-  vars:
-      ansible_python_interpreter: "{{ python2_bin }}"
+      - '"libselinux-python3" not in ansible_facts.packages'

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -13,27 +13,11 @@
       state: directory
       mode: '0755'
 
-- name: Pre Audit | If using git for content set up
-  block:
-  - name: Pre Audit | Install git (rh8 python3)
-    package:
-        name: git
-        state: present
-    when: ansible_distribution_major_version == 8
-
-  - name: Pre Audit | Install git (rh7 python2)
-    package:
-        name: git
-        state: present
-    vars:
-        ansible_python_interpreter: "{{ python2_bin }}"
-    when: ansible_distribution_major_version == 7
-
-  - name: Pre Audit | retrieve audit content files from git
-    git:
-        repo: "{{ audit_file_git }}"
-        dest: "{{ audit_conf_dir }}"
-        version: "{{ audit_git_version }}"
+- name: Pre Audit | retrieve audit content files from git
+  git:
+      repo: "{{ audit_file_git }}"
+      dest: "{{ audit_conf_dir }}"
+      version: "{{ audit_git_version }}"
   when:
   - audit_content == 'git'
 

--- a/tasks/section_5/cis_5.5.x.yml
+++ b/tasks/section_5/cis_5.5.x.yml
@@ -32,32 +32,7 @@
       - patch
       - rule_5.5.1
 
-- name: "5.5.2 | PATCH | Ensure system accounts are secured | pre RHEL8.2"
-  block:
-      - name: "5.5.2 | PATCH | Ensure lockout for failed password attempts is configured | pre RHEL8.2 | Add deny count and unlock time for preauth"
-        lineinfile:
-            path: /etc/pam.d/{{ item }}
-            regexp: '^auth\s*required\s*pam_faillock.so preauth'
-            line: "auth        required                                     pam_faillock.so preauth silent deny={{ rhel9cis_pam_faillock.attempts }}{{ (rhel9cis_pam_faillock.fail_for_root) | ternary(' even_deny_root ',' ') }}unlock_time={{ rhel9cis_pam_faillock.unlock_time }}"
-            insertafter: '^#?auth ?'
-        with_items:
-            - "system-auth"
-            - "password-auth"
-
-      - name: "5.5.2 | PATCH | Ensure lockout for failed password attempts is configured | pre RHEL8.2 | Add deny count and unlock times for authfail"
-        lineinfile:
-            path: /etc/pam.d/{{ item }}
-            regexp: '^auth\s*required\s*pam_faillock.so authfail'
-            line: "auth        required                                     pam_faillock.so authfail deny={{ rhel9cis_pam_faillock.attempts }}{{ (rhel9cis_pam_faillock.fail_for_root) | ternary(' even_deny_root ',' ') }}unlock_time={{ rhel9cis_pam_faillock.unlock_time }}"
-            insertafter: '^#?auth ?'
-        with_items:
-            - "system-auth"
-            - "password-auth"
-  when:
-      - ansible_distribution_version <= "8.1"
-      - rhel9cis_rule_5_5_2
-
-- name: "5.5.2 | PATCH | Ensure system accounts are secured | RHEL8.2+ "
+- name: "5.5.2 | PATCH | Ensure system accounts are secured"
   lineinfile:
       path: /etc/security/faillock.conf
       regexp: "{{ item.regexp }}"
@@ -66,7 +41,6 @@
       - { regexp: '^\s*deny\s*=\s*[1-5]\b', line: 'deny = 5' }
       - { regexp: '^\s*unlock_time\s*=\s*(0|9[0-9][0-9]|[1-9][0-9][0-9][0-9]+)\b', line: 'unlock_time = 900' }
   when:
-      - ansible_distribution_version >= "8.2"
       - rhel9cis_rule_5_5_2
 
 - name: "5.5.3 | PATCH | Ensure password reuse is limited"


### PR DESCRIPTION
**Overall Review of Changes:**
Remove Legacy checks no longer required for python2 and older OS release checks

Thanks to @alewando for highlighting this.
#13 

**How has this been tested?:**

Tested manually

