### PR TITLE
new option to 6_2_16 not follow symlinks

### DIFF
--- a/.github/workflows/linux_benchmark_testing.yml
+++ b/.github/workflows/linux_benchmark_testing.yml
@@ -91,7 +91,7 @@ jobs:
       - name: add urandom passwd to root account
         shell: bash
         run: |
-         ANSIBLE_HOST_KEY_CHECKING=False && ansible all -i .github/workflows/hosts.yml -m shell -a "cat /dev/urandom | tr -dc ‘[:print:]’ | head -c50 | passwd --stdin root" --private-key ${{ secrets.SSH_PRV_KEY }} -b
+         ANSIBLE_HOST_KEY_CHECKING=False && ansible all -i .github/workflows/hosts.yml -m shell -a "cat /dev/urandom | tr -dc ‘[:print:]’ | head -c50 | passwd --stdin root" -b
 
 # Run the ansible playbook
       - name: Run_Ansible_Playbook

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 Control 6_2_16 new variable added thanks to @dulin_gnet on rhel8  
 Will not follow ynlink in hoe directoris and amend permissions.
 
--rhel_09_6_2_16_home_follow_symlink: false
+- rhel_09_6_2_16_home_follow_symlink: false
 
 ## Initial CIS v1.0.0 - released Dec 2022
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Changes to rhel9CIS
 
+## 1.0.1
+
+Control 6_2_16 new variable added thanks to @dulin_gnet on rhel8  
+Will not follow ynlink in hoe directoris and amend permissions.
+
+-rhel_09_6_2_16_home_follow_symlink: false
+
 ## Initial CIS v1.0.0 - released Dec 2022
 
 ### Official CIS release

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -653,8 +653,14 @@ rhel9cis_rpm_audit_file: /var/tmp/rpm_file_check
 # RHEL-09_6.1.10 Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable
 rhel9cis_no_world_write_adjust: true
 rhel9cis_passwd_label: "{{ (this_item | default(item)).id }}: {{ (this_item | default(item)).dir }}"
-# 6.2.9
-rhel9cis_dotperm_ansiblemanaged: true
+
+
+# 6.2.16
+## Dont follow symlinks for changes to user home directory thanks to @dulin-gnet and comminty for rhel8-cis reedbacj
+rhel_09_6_2_16_home_follow_symlinks: false
+
+
+
 #### Goss Configuration Settings ####
 # Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
 audit_run_script_environment:

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -436,6 +436,7 @@
         ansible.builtin.file:
             path: "{{ item.path }}"
             mode: go-w
+            follow: "{{ rhel_09_6_2_16_home_follow_symlinks }}"
         loop: "{{ user_dot_files.files }}"
         loop_control:
             label: "{{ item.path }}"


### PR DESCRIPTION
Signed-off-by: Mark Bolwell <mark.bollyuk@gmail.com>

**Overall Review of Changes:**
Change to 6_2_16
It no longer follows symlinks by default as this has been fedback to cause issues.
Thanks to @dulin-gnet in the rhel8-cis PR for highlighting this issue.

**Enhancements:**
As above

**How has this been tested?:**
Manual


