### PR TITLE
Fixing typo for 'access_time' in tasks/section_1/cis_1.4.x.yml

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -28,7 +28,7 @@
             mode: "{{ item.mode }}"
             state: touch
             modification_time: preserve
-            acess_time: preserve
+            access_time: preserve
         loop:
             - { path: 'grub.cfg', mode: '0700' }
             - { path: 'grubenv', mode: '0600' }


### PR DESCRIPTION
**Overall Review of Changes:**
A typo in tasks/section_1/cis_1.4.x.yml causes the task to fail. access_time was misspelled as acess_time.

**Issue Fixes:**
- No issue raised

**Enhancements:**
- N/A (Bugfix)

**How has this been tested?:**
- Tested to solve the failing task on Rocky Linux 9 hosts.

