### PR TITLE
Fix system accounts rule 5.6.2

### DIFF
--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -13,7 +13,7 @@
             - item.id != "shutdown"
             - item.id != "halt"
             - item.id != "nfsnobody"
-            - min_int_uid | int < item.gid
+            - item.gid < min_int_uid | int
             - item.shell != "      /bin/false"
             - item.shell != "      /usr/sbin/nologin"
         loop_control:


### PR DESCRIPTION
**Overall Review of Changes:**
Found issue in tasks/section_5/cis_5.6.x.yml

**Issue Fixes:**
It seems to playbook change all user accounts shell to /usr/sbin/nologin

**How has this been tested?:**
Yes

