### PR TITLE
use ansible_facts to reference facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -692,12 +692,12 @@ audit_files_url: "some url maybe s3?"
 # Where the goss configs and outputs are stored
 audit_out_dir: '/opt'
 audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit/"
-pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_hostname }}-{{ benchmark }}_pre_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_hostname }}-{{ benchmark }}_post_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
+pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}_pre_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}_post_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
 
 ## The following should not need changing
 goss_file: "{{ audit_conf_dir }}goss.yml"
-audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_hostname }}.yml"
+audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
 audit_results: |
       The pre remediation results are: {{ pre_audit_summary }}.
       The post remediation results are: {{ post_audit_summary }}.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
 
 - name: Check OS version and family
   ansible.builtin.assert:
-      that: (ansible_distribution != 'CentOS' and ansible_os_family == 'RedHat' or ansible_os_family == "Rocky") and ansible_distribution_major_version is version_compare('9', '==')
-      fail_msg: "This role can only be run against Supported OSs. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
-      success_msg: "This role is running against a supported OS {{ ansible_distribution }} {{ ansible_distribution_major_version }}"
+      that: (ansible_facts.distribution != 'CentOS' and ansible_facts.os_family == 'RedHat' or ansible_facts.os_family == "Rocky") and ansible_facts.distribution_major_version is version_compare('9', '==')
+      fail_msg: "This role can only be run against Supported OSs. {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }} is not supported."
+      success_msg: "This role is running against a supported OS {{ ansible_facts.distribution }} {{ ansible_facts.distribution_major_version }}"
   when:
       - os_check
       - not system_is_ec2
@@ -81,7 +81,7 @@
             - system_is_container
   when:
       - ansible_connection == 'docker' or
-        ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+        ansible_facts.virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
   tags:
       - container_discovery
       - always
@@ -109,7 +109,7 @@
       - always
 
 - name: Include OS specific variables
-  ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_facts.distribution }}.yml"
   tags:
       - always
 

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -88,7 +88,7 @@
 
 - name: "PRELIM | Section 1.1 | Create list of mount points"
   ansible.builtin.set_fact:
-      mount_names: "{{ ansible_mounts | map(attribute='mount') | list }}"
+      mount_names: "{{ ansible_facts.mounts | map(attribute='mount') | list }}"
   tags:
       - level1-server
       - level1-workstation
@@ -124,8 +124,8 @@
       state: latest
   when:
       - rhel9cis_rule_1_2_4
-      - ansible_distribution != 'RedHat'
-      - ansible_distribution != 'OracleLinux'
+      - ansible_facts.distribution != 'RedHat'
+      - ansible_facts.distribution != 'OracleLinux'
 
 - name: "PRELIM | Section 4.1 | Configure System Accounting (auditd)"
   ansible.builtin.package:

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -33,7 +33,7 @@
       state: present
       opts: defaults,{% if rhel9cis_rule_1_1_2_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_2_3 %}noexec,{% endif %}{% if rhel9cis_rule_1_1_2_4 %}nosuid{% endif %}
   notify: Remount tmp
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   when:

--- a/tasks/section_1/cis_1.1.3.x.yml
+++ b/tasks/section_1/cis_1.1.3.x.yml
@@ -31,7 +31,7 @@
       fstype: "{{ item.fstype }}"
       state: present
       opts: defaults,{% if rhel9cis_rule_1_1_3_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_3_3 %}nosuid,{% endif %}
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   notify: Change_requires_reboot

--- a/tasks/section_1/cis_1.1.4.x.yml
+++ b/tasks/section_1/cis_1.1.4.x.yml
@@ -33,7 +33,7 @@
       fstype: "{{ item.fstype }}"
       state: present
       opts: defaults,{% if rhel9cis_rule_1_1_4_2 %}noexec,{% endif %}{% if rhel9cis_rule_1_1_4_3 %}nosuid,{% endif %}{% if rhel9cis_rule_1_1_4_4 %}nodev{% endif %}
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   notify: Change_requires_reboot

--- a/tasks/section_1/cis_1.1.5.x.yml
+++ b/tasks/section_1/cis_1.1.5.x.yml
@@ -33,7 +33,7 @@
       fstype: "{{ item.fstype }}"
       state: present
       opts: defaults,{% if rhel9cis_rule_1_1_5_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_5_3 %}noexec,{% endif %}{% if rhel9cis_rule_1_1_5_4 %}nosuid{% endif %}
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   notify: Change_requires_reboot

--- a/tasks/section_1/cis_1.1.6.x.yml
+++ b/tasks/section_1/cis_1.1.6.x.yml
@@ -32,7 +32,7 @@
       fstype: "{{ item.fstype }}"
       state: present
       opts: defaults,{% if rhel9cis_rule_1_1_6_2 %}noexec,{% endif %}{% if rhel9cis_rule_1_1_6_3 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_6_4 %}nosuid{% endif %}
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   notify: Change_requires_reboot

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -32,7 +32,7 @@
       fstype: "{{ item.fstype }}"
       state: present
       opts: defaults,{% if rhel9cis_rule_1_1_7_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_7_3 %}nosuid,{% endif %}
-  loop: "{{ ansible_mounts }}"
+  loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"
   notify: Change_requires_reboot

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -23,9 +23,9 @@
               os_gpg_key_check.rc == 1
   when:
       - rhel9cis_rule_1_2_1
-      - ansible_distribution == "RedHat" or
-        ansible_distribution == "Rocky" or
-        ansible_distribution == "AlmaLinux"
+      - ansible_facts.distribution == "RedHat" or
+        ansible_facts.distribution == "Rocky" or
+        ansible_facts.distribution == "AlmaLinux"
   tags:
       - level1-server
       - level1-workstation
@@ -111,8 +111,8 @@
 
   when:
       - rhel9cis_rule_1_2_4
-      - not rhel9cis_rhel_default_repo or ansible_distribution != 'RedHat'
-      - ansible_distribution != 'OracleLinux'
+      - not rhel9cis_rhel_default_repo or ansible_facts.distribution != 'RedHat'
+      - ansible_facts.distribution != 'OracleLinux'
   tags:
       - level1-server
       - level1-workstation

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -155,7 +155,7 @@
         failed_when: false
         check_mode: false
         register: rhel_09_6_1_10_audit
-        loop: "{{ ansible_mounts }}"
+        loop: "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
         when: item['device'].startswith('/dev') and not 'bind' in item['options']
@@ -196,7 +196,7 @@
         failed_when: false
         changed_when: false
         register: rhel_09_6_1_11_audit
-        loop: "{{ ansible_mounts }}"
+        loop: "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
         when: item['device'].startswith('/dev') and not 'bind' in item['options']
@@ -250,7 +250,7 @@
         failed_when: false
         changed_when: false
         register: rhel_09_6_1_13_suid_perms
-        loop: "{{ ansible_mounts }}"
+        loop: "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
 
@@ -289,7 +289,7 @@
         failed_when: false
         changed_when: false
         register: rhel_09_6_1_14_sgid_perms
-        loop: "{{ ansible_mounts }}"
+        loop: "{{ ansible_facts.mounts }}"
         loop_control:
             label: "{{ item.mount }}"
 

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -7,7 +7,7 @@ benchmark_version: '1.0.0'
 
 # Set if genuine RHEL (subscription manager check) not for derivatives e.g. CentOS
 # If run via script this is discovered and set
-host_os_distribution: {{ ansible_distribution | lower }}
+host_os_distribution: {{ ansible_facts.distribution | lower }}
 
 #  timeout for each command to run where set - default = 10seconds/10000ms
 timeout_ms: 60000

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,4 +11,4 @@ rhel9cis_allowed_crypto_policies:
 warn_control_list: ""
 warn_count: 0
 
-gpg_key_package: "{{ ansible_distribution | lower }}-gpg-keys"
+gpg_key_package: "{{ ansible_facts.distribution | lower }}-gpg-keys"


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with ansible_. This can result in a large number of variables for each host, which at scale can incur a performance penalty. Ansible provides a configuration option [0] that can be set to False to prevent this injection of facts. In this case, facts should be referenced via ansible_facts..

This change updates all references to Ansible facts from using individual fact variables to using the items in the ansible_facts dictionary. This allows users to disable fact variable injection in their Ansible configuration, which may provide some performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars

**Overall Review of Changes:**
A general description of the changes made that are being requested for merge

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

