### PR TITLE
Molecule test on container is failing due to modprobe

### DIFF
--- a/tasks/section_1/cis_1.1.x.yml
+++ b/tasks/section_1/cis_1.1.x.yml
@@ -16,6 +16,7 @@
         community.general.modprobe:
             name: usb-storage
             state: absent
+        when: not system_is_container      
 
       - name: "1.1.9 | PATCH | Disable USB Storage | blacklist"
         ansible.builtin.lineinfile:


### PR DESCRIPTION
**Overall Review of Changes:**
As modprobe is not available on containers, a molecule test for this role fails. 
I've added a flag to skip "1.1.9 | PATCH | Disable USB Storage | Edit modprobe config" if **system_is_container** var is set to **true**. 

This way the molecule test should work. 

**How has this been tested?:**
Yes, testing works with Molecule/podman. 

