### PR TITLE
Use correct backtick for regex escape

### DIFF
--- a/tasks/section_4/cis_4.2.2.x.yml
+++ b/tasks/section_4/cis_4.2.2.x.yml
@@ -185,7 +185,7 @@
       - name: "4.2.2.7 | PATCH | Ensure journald default file permissions configured | Set permission"
         ansible.builtin.lineinfile:
             path: "{{ systemd_conf_file | default('/usr/lib/tmpfiles.d/systemd.conf') }}"
-            regexp: "^z \/var\/log\/journal\/%m\/system.journal (!?06(0|4)0) root"
+            regexp: '^z \/var\/log\/journal\/%m\/system.journal (!?06(0|4)0) root'
             line: 'z /var/log/journal/%m/system.journal 0640 root systemd-journal - -'
 
   when:


### PR DESCRIPTION
**Overall Review of Changes:**
Depends on the ansible version regex escape (via slash) require correct backticks to work. Otherwise it would result in a syntax error.

**Issue Fixes:**

```
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)
Syntax Error while loading YAML.
  found unknown escape character
The error appears to be in '/runner/project/tasks/section_4/cis_4.2.2.x.yml': line 188, column 25, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
            path: "{{ systemd_conf_file | default('/usr/lib/tmpfiles.d/systemd.conf') }}"
            regexp: "^z \/var\/log\/journal\/%m\/system.journal (!?06(0|4)0) root"
                        ^ here
```

**How has this been tested?:**
The issue was detected with the latest Ansible Tower / Ansible Automation Platform version. After adding the change in the merge request the playbook worked.
