### PR TITLE
use a distro specific file for GPG vars

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -4,5 +4,8 @@
   connection: local
   become: true
 
+  vars_files:
+    - "{{ ansible_distribution }}.yml"
+
   roles:
   - role: "{{ playbook_dir }}"

--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,9 @@
 - hosts: all  # noqa: name[play]
   become: true
 
+  vars_files:
+    - "{{ ansible_distribution }}.yml"
+
   roles:
 
       - role: "{{ playbook_dir }}"


### PR DESCRIPTION
**Overall Review of Changes:**
I encountered the error message below when running the playbook. 
Turns out the OS/distro specific var files from this role aren't in use. I don't see them being included anywhere and thus the error occurred since the variables aren't loaded.

```
TASK [/home/user/rhel9_cis : 1.2.1 | AUDIT | Ensure GPG keys are configured | list installed pubkey keys] ********************************************************************
fatal: [192.168.92.137]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'os_gpg_key_pubkey_name' is undefined. 'os_gpg_key_pubkey_name' is undefined\n\nThe error appears to be in '/home/user/rhel9_cis/tasks/sec1/1.2.x.yaml': line 5, column 9, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n      - name: \"1.2.1 | AUDIT | Ensure GPG keys are configured | list installed pubkey keys\"\n        ^ here\n"}

PLAY RECAP *********************************************************************************************************************************************************************************************************
192.168.92.137             : ok=49   changed=0    unreachable=0    failed=1    skipped=12   rescued=0    ignored=0
```

**Issue Fixes:**
As per error above. 

**How has this been tested?:**
Yes, tested this on my Rocky9 VM and it works after adding the **vars_files**. 
```
TASK [/home/user/rhel9_cis: 1.2.1 | AUDIT | Ensure GPG keys are configured | list installed pubkey keys] ********************************************************************
ok: [192.168.92.137]
```
