### PR TITLE
Fix 2.2.14 evaluate dnsmasq instead of postfix

### DIFF
--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -228,9 +228,8 @@
   ansible.builtin.package:
       name: dnsmasq
       state: absent
-  notify: Restart postfix
   when:
-      - not rhel9cis_is_mail_server
+      - not rhel9cis_dnsmasq_server
       - "'dnsmasq' in ansible_facts.packages"
       - rhel9cis_rule_2_2_14
   tags:


### PR DESCRIPTION
Corrected rule 2.2.14 Ensure dnsmasq is not installed (Automated) on an RHEL 9 machine without postfix.

**Overall Review of Changes:**
Fixed 2.2.14 to evaluate dnsmasq instead of postfix.

**Issue Fixes:**
Previous code evaluate postfix and triggers postfix restart handler when is not needed.

```
RUNNING HANDLER [RHEL9-CIS : Restart postfix] ************************************************
fatal: [rhel.example.com]: FAILED! => {"changed": false, "msg": "Could not find the requested service postfix: host"}
```

**Enhancements:**
Running the code on a machine without "postfix" installed didn't end with the "Restart postfix" handler error.

**How has this been tested?:**
Tested locally on freshly installed RHEL9 with `rhel9cis_dnsmasq_server = false`  and `rhel9cis_is_mail_server  = false` .

