### PR TITLE
improve password check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 # Changes to rhel9CIS
 
+## 1.0.10
+
+- [#72](https://github.com/ansible-lockdown/RHEL9-CIS/issues/72)
+  - Only run check when paybook user not a superuser
+
 ## 1.0.9
+
 fixed assert for user password set
 
 thanks to @byjunks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
             sudo_password_rule: rhel9cis_rule_5_3_4
   when:
       - rhel9cis_rule_5_3_4
+      - ansible_env.SUDO_USER is defined
       - not system_is_ec2
   tags:
       - user_passwd


### PR DESCRIPTION
Overall Review of Changes:
Improve password check for rule 5.3.4 that sudo user must have a password or sudo will fail to work.

Issue Fixes:
[72](https://github.com/ansible-lockdown/RHEL9-CIS/issues/72)

Enhancements:
Only run if the playbook is not being run as a super user

How has this been tested?:
Manually