### PR TITLE
Fix file path to /etc/group

### DIFF
--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -32,7 +32,7 @@
 
 - name: "6.1.3 | PATCH | Ensure permissions on /etc/group are configured"
   ansible.builtin.file:
-      path: /etc/group-
+      path: /etc/group
       owner: root
       group: root
       mode: 0644


### PR DESCRIPTION
**Overall Review of Changes:**
Bug fix for section [6_1_3](https://github.com/ansible-lockdown/RHEL9-CIS/blob/f683323262e97fb740a4bf1ae4ab311dcc6ac575/tasks/section_6/cis_6.1.x.yml#L35) where wrong file permissions are checked agaist.

**Issue Fixes:**
Bug fix where wrong file was used, /etc/group- instead of /etc/group

**How has this been tested?:**
Tested on server with operating system AlmaLinux release 9.1 (Lime Lynx), by running instructions for ansible playbook.
