### PR TITLE
find hidden files in /var/log for 4.3.2

### DIFF
--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -7,6 +7,7 @@
             paths: "/var/log"
             file_type: file
             recurse: true
+            hidden: true
         register: logfiles
 
       - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | change permissions"


### PR DESCRIPTION
**Overall Review of Changes:**
Allow the find module to find hidden file in /var/log/

**Issue Fixes:**
Addresses a failure on section  [4.2.3 Ensure permission on all log files are configured]. The issue is that when using VMware guest customisation to provision VMs, it produce a hidden file “/var/log/.vmware-deploy.Done”. The find module defaults to hidden: false and so is not fixing this permissions issue in a later step.

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Tested against AlmaLinux 9.2 VM provisioned in vSphere

