### PR TITLE
Adding missing lines to usr: sysctl.d/50-default.conf

### DIFF
--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -26,6 +26,19 @@
       - not system_is_container
       - "'procps-ng' in ansible_facts.packages"
 
+- name: POST | Update usr sysctl
+  ansible.builtin.lineinfile:
+      dest: /usr/lib/sysctl.d/50-default.conf
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+  loop:
+      - { regexp: '^net.ipv4.conf.default.rp_filter', line: 'net.ipv4.conf.default.rp_filter = 1' }
+      - { regexp: '^net.ipv4.conf.*.rp_filter', line: 'net.ipv4.conf.*.rp_filter = 1' }
+  when:
+      - rhel9cis_sysctl_update
+      - not system_is_container
+      - "'procps-ng' in ansible_facts.packages"
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
**Overall Review of Changes:**
Adds entries to: `/usr/lib/sysctl.d/50-default.conf` required by CIS-CAT assessor.
On control: 3.3.7 Ensure Reverse Path Filtering is enabled.

**Issue Fixes:**
Fixes #106

**Enhancements:**
Entries in: `/usr/lib/sysctl.d/50-default.conf`

**How has this been tested?:**
Manually and with ansible lockdown package.

