### PR TITLE
Adding new entry in /etc/pam.d/system-auth

### DIFF
--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -98,6 +98,11 @@
             regexp: '^USERGROUPS_ENAB'
             line: USERGROUPS_ENAB no
 
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Force umask sessions /etc/pam.d/system-auth"
+        ansible.builtin.lineinfile:
+            path: /etc/pam.d/system-auth
+            line: 'session     required            pam_umask.so'
+            insertafter: EOF
   when:
       - rhel9cis_rule_5_6_5
   tags:


### PR DESCRIPTION
Overall Review of Changes:
Added entry on cis_5.6.x.yml covering the issue found.

Issue Fixes:
#107 
Fixes https://github.com/ansible-lockdown/RHEL9-CIS/issues/107

Enhancements:
Solves issue not covered previously.
Found in assessment.

How has this been tested?:
Manually and with lockdown package.