### PR TITLE
5.6.1.2 Adding solution for users with passwords.

### DIFF
--- a/tasks/section_5/cis_5.6.1.x.yml
+++ b/tasks/section_5/cis_5.6.1.x.yml
@@ -15,10 +15,25 @@
       - rule_5.5.1.1
 
 - name: "5.6.1.2 | PATCH | Ensure minimum days between password changes is 7 or more"
-  ansible.builtin.lineinfile:
-      path: /etc/login.defs
-      regexp: '^PASS_MIN_DAYS'
-      line: "PASS_MIN_DAYS {{ rhel9cis_pass['min_days'] }}"
+  block:
+    - name: "5.6.1.2 | PATCH | Set default."
+      ansible.builtin.lineinfile:
+        path: /etc/login.defs
+        regexp: '^PASS_MIN_DAYS'
+        line: "PASS_MIN_DAYS {{ rhel9cis_pass['min_days'] }}"
+      
+    - name: "5.6.1.2 | AUDIT | Get existing users"
+      ansible.builtin.getent:
+        database: shadow
+
+    - name: "5.6.1.2 | PATCH | Set existing users"
+      ansible.builtin.user:
+        name: "{{ item }}"
+        password_expire_min: "{{ rhel9cis_pass['min_days'] }}"
+      loop: "{{ getent_shadow | dict2items | map(attribute='key') | list  }}"
+      when: ( getent_shadow[item].0 != "!!" ) and
+            ( getent_shadow[item].0 != "!*" ) and
+            ( getent_shadow[item].0 != "*" )
   when:
       - rhel9cis_rule_5_6_1_2
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
Adds mesure to address existing users with password set.

**Issue Fixes:**
Fixes #109

**Enhancements:**
Checks for users with password set and sets min days to password.

**How has this been tested?:**
Manually and with ansible lockdown package, using vanilla installation.

