### PR TITLE
Audit only enhancement and goss update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Changes to rhel9CIS
 
+## 1.1.3 - Based on CIS v1.0.0
+
+- updated goss binary to 0.4.4
+- moved majority of audit variables to vars/audit.yml
+- new function to enable audit_only using remediation
+- removed some dupes in audit config
+
 ## 1.1.2 - Based on CIS v1.0.0
 
 - updated audit binary versions - aligned with rhel9-cis-audit

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,28 +45,53 @@ skip_reboot: true
 # default value will change to true but wont reboot if not enabled but will error
 change_requires_reboot: false
 
-#### Basic external goss audit enablement settings ####
-#### Precise details - per setting can be found at the bottom of this file ####
+##########################################
+### Goss is required on the remote host ###
+## Refer to vars/auditd.yml for any other settings ##
 
-### Goss is required on the remote host
+# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
 setup_audit: false
-# How to retrive goss
+
+# enable audits to run - this runs the audit and get the latest content
+run_audit: false
+
+# Only run Audit do not remediate
+audit_only: false
+# As part of audit_only
+# This will enable files to be copied back to control node
+fetch_audit_files: false
+# Path to copy the files to will create dir structure
+audit_capture_files_dir: /some/location to copy to on control node
+
+# How to retrieve audit binary
 # Options are copy or download - detailed settings at the bottom of this file
 # you will need to access to either github or the file already dowmloaded
 get_audit_binary_method: download
 
+## if get_audit_binary_method - copy the following needs to be updated for your environment
+## it is expected that it will be copied from somewhere accessible to the control node
+## e.g copy from ansible control node to remote host
+audit_bin_copy_location: /some/accessible/path
+
 # how to get audit files onto host options
-# options are git/copy/get_url - use local if already available to to the host (adjust paths accordingly)
+# options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
 audit_content: git
 
-# enable audits to run - this  runs the audit and get the latest content
-run_audit: false
+# archive or copy:
+audit_conf_copy: "some path to copy from"
 
-# Timeout for those cmds that take longer to run where timeout set
-audit_cmd_timeout: 60000
+# get_url:
+audit_files_url: "some url maybe s3?"
+
+# Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
+audit_run_heavy_tests: true
+
+# This variable specifies the timeout (in ms) for audit commands that
+# take a very long time: if a command takes too long to complete,
+# it will be forcefully terminated after the specified duration.
+audit_cmd_timeout: 120000
 
 ### End Goss enablements ####
-#### Detailed settings found at the end of this document ####
 
 # These variables correspond with the CIS rule IDs or paragraph numbers defined in
 # the CIS benchmark documents.
@@ -663,47 +688,3 @@ audit_run_script_environment:
     AUDIT_BIN: "{{ audit_bin }}"
     AUDIT_FILE: 'goss.yml'
     AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-
-### Goss binary settings ###
-audit_bin_release: v0.4.2
-audit_bin_version:
-    AMD64_checksum: 'sha256:e50e43d75c47c731f5fdff176f5abeb8aca35f17aea60f85ebc28f6110cb6945'
-    ARM64_checksum: 'sha256:6da14a98f12d1929ea719d4cfe96087c8e3a37b29d91b72fbe6edc7f8a580784 '
-audit_bin_path: /usr/local/bin/
-audit_bin: "{{ audit_bin_path }}goss"
-audit_format: json
-
-# if get_goss_file == download change accordingly
-audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_release }}/goss-linux-"
-
-## if get_goss_file - copy the following needs to be updated for your environment
-## it is expected that it will be copied from somewhere accessible to the control node
-## e.g copy from ansible control node to remote host
-copy_goss_from_path: /some/accessible/path
-
-### Goss Audit Benchmark file ###
-## managed by the control audit_content
-# git
-audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
-audit_git_version: "benchmark_{{ benchmark_version }}"
-
-# copy:
-audit_local_copy: "some path to copy from"
-
-# get_url:
-audit_files_url: "some url maybe s3?"
-
-## Goss configuration information
-# Where the goss configs and outputs are stored
-audit_out_dir: '/opt'
-audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit/"
-pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}_pre_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
-post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}_post_scan_{{ ansible_date_time.epoch }}.{{ audit_format }}"
-
-## The following should not need changing
-goss_file: "{{ audit_conf_dir }}goss.yml"
-audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
-audit_results: |
-      The pre remediation results are: {{ pre_audit_summary }}.
-      The post remediation results are: {{ post_audit_summary }}.
-      Full breakdown can be found in {{ audit_out_dir }}

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -23,7 +23,7 @@
   when:
       - get_audit_binary_method == 'download'
 
-- name: Pre Audit Setup | copy audit binary
+- name: Pre Audit Setup | Copy audit binary
   ansible.builtin.copy:
       src: "{{ audit_bin_copy_location }}"
       dest: "{{ audit_bin }}"

--- a/tasks/audit_only.yml
+++ b/tasks/audit_only.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Audit_Only | Create local Directories for hosts
+  ansible.builtin.file:
+      mode: '0755'
+      path: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}"
+      recurse: true
+      state: directory
+  when: fetch_audit_files
+  delegate_to: localhost
+  become: false
+
+- name: Audit_only | Get audits from systems and put in group dir
+  ansible.builtin.fetch:
+      dest: "{{ audit_capture_files_dir }}/{{ inventory_hostname }}/"
+      flat: true
+      mode: '0644'
+      src: "{{ pre_audit_outfile }}"
+  when: fetch_audit_files
+
+- name: Audit_only | Show Audit Summary
+  when:
+      - audit_only
+  ansible.builtin.debug:
+      msg: "The Audit results are: {{ pre_audit_summary }}."
+
+- name: Audit_only | Stop Playbook Audit Only selected
+  when:
+      - audit_only
+  ansible.builtin.meta: end_play

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,11 +133,22 @@
       - prelim_tasks
       - always
 
-- name: run pre_remediation audit
-  ansible.builtin.include_tasks:
-      file: pre_remediation_audit.yml
+- name: Include audit specific variables
   when:
+      - run_audit or audit_only
+      - setup_audit
+  tags:
+      - setup_audit
       - run_audit
+  ansible.builtin.include_vars: audit.yml
+
+- name: Include pre-remediation audit tasks
+  when:
+      - run_audit or audit_only
+      - setup_audit
+  tags:
+      - run_audit
+  ansible.builtin.import_tasks: pre_remediation_audit.yml
 
 - name: run Section 1 tasks
   ansible.builtin.import_tasks:

--- a/tasks/post_remediation_audit.yml
+++ b/tasks/post_remediation_audit.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: "Post Audit | Run post_remediation {{ benchmark }} audit"
+- name: Post Audit | Run post_remediation {{ benchmark }} audit
   ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ post_audit_outfile }} -g {{ group_names }}"
   changed_when: true
   environment:
       AUDIT_BIN: "{{ audit_bin }}"
       AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-      AUDIT_FILE: "goss.yml"
+      AUDIT_FILE: goss.yml
 
 - name: Post Audit | ensure audit files readable by users
   ansible.builtin.file:
@@ -18,9 +18,11 @@
       - "{{ pre_audit_outfile }}"
 
 - name: Post Audit | Capture audit data if json format
+  when:
+      - audit_format == "json"
   block:
-      - name: "capture data {{ post_audit_outfile }}"
-        ansible.builtin.shell: "cat {{ post_audit_outfile }}"
+      - name: capture data {{ post_audit_outfile }}
+        ansible.builtin.shell: cat {{ post_audit_outfile }}
         register: post_audit
         changed_when: false
 
@@ -28,19 +30,17 @@
         ansible.builtin.set_fact:
             post_audit_summary: "{{ post_audit.stdout | from_json | json_query(summary) }}"
         vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
+            summary: summary."summary-line"
 
 - name: Post Audit | Capture audit data if documentation format
+  when:
+      - audit_format == "documentation"
   block:
-      - name: "Post Audit | capture data {{ post_audit_outfile }}"
-        ansible.builtin.shell: "tail -2 {{ post_audit_outfile }}"
+      - name: Post Audit | capture data {{ post_audit_outfile }}
+        ansible.builtin.shell: tail -2 {{ post_audit_outfile }}
         register: post_audit
         changed_when: false
 
       - name: Post Audit | Capture post-audit result
         ansible.builtin.set_fact:
             post_audit_summary: "{{ post_audit.stdout_lines }}"
-  when:
-      - audit_format == "documentation"

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -1,56 +1,58 @@
 ---
 
-- name: Pre Audit Binary Setup | Setup the LE audit
-  ansible.builtin.include_tasks: LE_audit_setup.yml
+- name: Pre Audit Setup | Setup the LE audit
   when:
       - setup_audit
   tags:
       - setup_audit
+  ansible.builtin.include_tasks: LE_audit_setup.yml
 
-- name: "Pre Audit Setup | Ensure {{ audit_conf_dir }} exists"
+- name: Pre Audit Setup | Ensure {{ audit_conf_dir }} exists
   ansible.builtin.file:
       path: "{{ audit_conf_dir }}"
       state: directory
       mode: '0755'
 
 - name: Pre Audit Setup | If using git for content set up
+  when:
+      - audit_content == 'git'
   block:
       - name: Pre Audit Setup | Install git
         ansible.builtin.package:
             name: git
             state: present
 
-      - name: Pre Audit Setup | retrieve audit content files from git
+      - name: Pre Audit Setup | Retrieve audit content files from git
         ansible.builtin.git:
             repo: "{{ audit_file_git }}"
             dest: "{{ audit_conf_dir }}"
             version: "{{ audit_git_version }}"
-  when:
-      - audit_content == 'git'
 
-- name: Pre Audit Setup | copy to audit content files to server
+- name: Pre Audit Setup | Copy to audit content files to server
+  when:
+      - audit_content == 'copy'
   ansible.builtin.copy:
       src: "{{ audit_local_copy }}"
       dest: "{{ audit_conf_dest }}"
       mode: preserve
-  when:
-      - audit_content == 'copy'
 
-- name: Pre Audit Setup | unarchive audit content files on server
+- name: Pre Audit Setup | Unarchive audit content files on server
+  when:
+      - audit_content == 'archived'
   ansible.builtin.unarchive:
       src: "{{ audit_conf_copy  }}"
       dest: "{{ audit_conf_dir }}"
-  when:
-      - audit_content == 'archived'
 
-- name: Pre Audit Setup | get audit content from url
+- name: Pre Audit Setup | Get audit content from url
+  when:
+      - audit_content == 'get_url'
   ansible.builtin.get_url:
       url: "{{ audit_files_url }}"
       dest: "{{ audit_conf_dir }}"
-  when:
-      - audit_content == 'get_url'
 
 - name: Pre Audit Setup | Check Goss is available
+  when:
+      - run_audit
   block:
       - name: Pre Audit Setup | Check for goss file
         ansible.builtin.stat:
@@ -58,36 +60,36 @@
         register: goss_available
 
       - name: Pre Audit Setup | If audit ensure goss is available
-        ansible.builtin.assert:
-            msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
         when:
             - not goss_available.stat.exists
-  when:
-      - run_audit
+        ansible.builtin.assert:
+            msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
 
 - name: Pre Audit Setup | Copy ansible default vars values to test audit
+  tags:
+      - goss_template
+      - run_audit
+  when:
+      - run_audit
   ansible.builtin.template:
       src: ansible_vars_goss.yml.j2
       dest: "{{ audit_vars_path }}"
       mode: '0600'
-  when:
-      - run_audit
-  tags:
-      - goss_template
-      - always
 
-- name: "Pre Audit | Run pre_remediation {{ benchmark }} audit"
+- name: Pre Audit | Run pre_remediation {{ benchmark }} audit
   ansible.builtin.shell: "{{ audit_conf_dir }}/run_audit.sh -v {{ audit_vars_path }} -o {{ pre_audit_outfile }} -g {{ group_names }}"
   changed_when: true
   environment:
       AUDIT_BIN: "{{ audit_bin }}"
       AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
-      AUDIT_FILE: "goss.yml"
+      AUDIT_FILE: goss.yml
 
 - name: Pre Audit | Capture audit data if json format
+  when:
+      - audit_format == "json"
   block:
-      - name: "capture data {{ pre_audit_outfile }}"
-        ansible.builtin.shell: "cat {{ pre_audit_outfile }}"
+      - name: capture data {{ pre_audit_outfile }}
+        ansible.builtin.shell: cat {{ pre_audit_outfile }}
         register: pre_audit
         changed_when: false
 
@@ -95,19 +97,22 @@
         ansible.builtin.set_fact:
             pre_audit_summary: "{{ pre_audit.stdout | from_json | json_query(summary) }}"
         vars:
-            summary: 'summary."summary-line"'
-  when:
-      - audit_format == "json"
+            summary: summary."summary-line"
 
 - name: Pre Audit | Capture audit data if documentation format
+  when:
+      - audit_format == "documentation"
   block:
-      - name: "Pre Audit | capture data {{ pre_audit_outfile }} | documentation format"
-        ansible.builtin.shell: "tail -2 {{ pre_audit_outfile }}"
+      - name: Pre Audit | capture data {{ pre_audit_outfile }} | documentation format
+        ansible.builtin.shell: tail -2 {{ pre_audit_outfile }}
         register: pre_audit
         changed_when: false
 
       - name: Pre Audit | Capture pre-audit result | documentation format
         ansible.builtin.set_fact:
             pre_audit_summary: "{{ pre_audit.stdout_lines }}"
+
+- name: Audit_Only | Run Audit Only
   when:
-      - audit_format == "documentation"
+      - audit_only
+  ansible.builtin.import_tasks: audit_only.yml

--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -239,7 +239,6 @@ rhel9cis_rule_4_1_4_10: {{ rhel9cis_rule_4_1_4_10 }}
 # 4.2.1 Configure rsyslog
 rhel9cis_rule_4_2_1_1: {{ rhel9cis_rule_4_2_1_1 }}
 rhel9cis_rule_4_2_1_2: {{ rhel9cis_rule_4_2_1_2 }}
-rhel9cis_rule_4_2_1_2: {{ rhel9cis_rule_4_2_1_3 }}
 rhel9cis_rule_4_2_1_3: {{ rhel9cis_rule_4_2_1_3 }}
 rhel9cis_rule_4_2_1_4: {{ rhel9cis_rule_4_2_1_4 }}
 rhel9cis_rule_4_2_1_5: {{ rhel9cis_rule_4_2_1_5 }}

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -1,0 +1,38 @@
+---
+
+#### Audit Configuration Settings ####
+
+# if get_audit_binary_method == download change accordingly
+audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_version.release }}/goss-linux-"
+
+### Goss Audit Benchmark file ###
+## managed by the control audit_content
+# git
+audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
+audit_git_version: "benchmark-{{ benchmark_version }}"
+
+## Goss configuration information
+# Where the goss configs and outputs are stored
+audit_out_dir: '/opt'
+# Where the goss audit configuration will be stored
+audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
+
+# If changed these can affect other products
+pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+post_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_post_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"
+
+## The following should not need changing
+
+### Audit binary settings ###
+audit_bin_version:
+    release: v0.4.4
+    AMD64_checksum: 'sha256:1c4f54b22fde9d4d5687939abc2606b0660a5d14a98afcd09b04b793d69acdc5'
+audit_bin_path: /usr/local/bin/
+audit_bin: "{{ audit_bin_path }}goss"
+audit_format: json
+
+audit_vars_path: "{{ audit_conf_dir }}/vars/{{ ansible_facts.hostname }}.yml"
+audit_results: |
+      The pre remediation results are: {{ pre_audit_summary }}.
+      The post remediation results are: {{ post_audit_summary }}.
+      Full breakdown can be found in {{ audit_out_dir }}

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -15,7 +15,7 @@ audit_git_version: "benchmark_{{ benchmark_version }}"
 # Where the goss configs and outputs are stored
 audit_out_dir: '/opt'
 # Where the goss audit configuration will be stored
-audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}_Audit"
+audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
 
 # If changed these can affect other products
 pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -9,7 +9,7 @@ audit_bin_url: "https://github.com/goss-org/goss/releases/download/{{ audit_bin_
 ## managed by the control audit_content
 # git
 audit_file_git: "https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"
-audit_git_version: "benchmark-{{ benchmark_version }}"
+audit_git_version: "benchmark_{{ benchmark_version }}"
 
 ## Goss configuration information
 # Where the goss configs and outputs are stored

--- a/vars/audit.yml
+++ b/vars/audit.yml
@@ -15,7 +15,7 @@ audit_git_version: "benchmark-{{ benchmark_version }}"
 # Where the goss configs and outputs are stored
 audit_out_dir: '/opt'
 # Where the goss audit configuration will be stored
-audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}-Audit"
+audit_conf_dir: "{{ audit_out_dir }}/{{ benchmark }}_Audit"
 
 # If changed these can affect other products
 pre_audit_outfile: "{{ audit_out_dir }}/{{ ansible_facts.hostname }}-{{ benchmark }}-{{ benchmark_version }}_pre_scan_{{ ansible_facts.date_time.epoch }}.{{ audit_format }}"


### PR DESCRIPTION
**Overall Review of Changes:**
Updated goss to version 0.4.4
Added new functionality to allow the audit to be run and then complete with feedback

**Enhancements:**
- updated goss binary to 0.4.4
- moved majority of audit variables to vars/audit.yml
- new function to enable audit_only using remediation
- removed some dupes in audit config

**How has this been tested?:**
Manually and running audit_only

