### PR TITLE
3.4.2.5 conditional fix

### DIFF
--- a/tasks/section_3/cis_3.4.2.x.yml
+++ b/tasks/section_3/cis_3.4.2.x.yml
@@ -194,6 +194,7 @@
                 - "{{ rhel9cis_3_4_2_5_servicesport.stdout_lines }}"
   when:
       - rhel9cis_rule_3_4_2_5
+      - rhel9cis_firewall == "firewalld"
   tags:
       - level1-server
       - level1-workstation


### PR DESCRIPTION
Missing conditional statement for firewalld rule(`3.4.2.5 | AUDIT | Ensure firewalld drops unnecessary services and ports`).

**Overall Review of Changes:**
Same behavior as for 3.4.2.4.

**Issue Fixes:**
#139 

**How has this been tested?:**
 N/A

