### PR TITLE
Using rhel9cis_authselect['options'], otherwise not used at all

### DIFF
--- a/tasks/section_5/cis_5.4.x.yml
+++ b/tasks/section_5/cis_5.4.x.yml
@@ -44,7 +44,7 @@
                 - "{{ rhel9cis_5_4_2_profiles_faillock.stdout_lines }}"
 
       - name: "5.4.2 | PATCH | Ensure authselect includes with-faillock | Create custom profiles"
-        ansible.builtin.shell: "authselect select custom/{{ rhel9cis_authselect['custom_profile_name'] }} with-faillock"
+        ansible.builtin.shell: "authselect select custom/{{ rhel9cis_authselect['custom_profile_name'] }}  {{ rhel9cis_authselect['options'] }}"
         when: rhel9cis_authselect_custom_profile_select
 
       - name: 5.4.2 | PATCH | Ensure authselect includes with-faillock | not auth select profile"


### PR DESCRIPTION
**Overall Review of Changes:**
Potential fix which includes var usage for `rhel9cis_authselect` -> `options`.

**Issue Fixes:**
#144 

**How has this been tested?:**
N/A

