### PR TITLE
Align RHEL9 hardening to RHEL8 to pass OpenSCAP check

### DIFF
--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -31,7 +31,7 @@
   ansible.builtin.lineinfile:
       path: /etc/sudoers
       regexp: '^Defaults    logfile='
-      line: 'Defaults    logfile="{{ rhel9cis_sudolog_location }}"'
+      line: 'Defaults    logfile={{ rhel9cis_sudolog_location }}'
       validate: '/usr/sbin/visudo -cf %s'
   when:
       - rhel9cis_rule_5_3_3


### PR DESCRIPTION
**Overall Review of Changes:**
OpenSCAP checks if the sudo logfile definition exists in `/etc/sudoers`. If the path is wrapped with quotes the check fails. The RHEL8 CIS task does it without quotes: https://github.com/ansible-lockdown/RHEL8-CIS/blob/devel/tasks/section_5/cis_5.3.x.yml#L35

![image](https://github.com/ansible-lockdown/RHEL9-CIS/assets/11320859/d34f4d62-ee3f-47f7-9365-6ab6b1891694)


**Issue Fixes:**
No open issue.

**Enhancements:**
OpenSCAP will accept the hardening.

**How has this been tested?:**
N/A

