### PR TITLE
Remove trailing comma to align with other roles

### DIFF
--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -32,7 +32,7 @@
       src: "{{ item.device }}"
       fstype: "{{ item.fstype }}"
       state: present
-      opts: defaults,{% if rhel9cis_rule_1_1_7_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_7_3 %}nosuid,{% endif %}
+      opts: defaults,{% if rhel9cis_rule_1_1_7_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_7_3 %}nosuid{% endif %}
   loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"


### PR DESCRIPTION
**Overall Review of Changes:**
 This PR simply removes a trailing comma to align the format with the other partition rules.

**Issue Fixes:**
 No technical change, only cosmetic.

**Enhancements:**
 Align /var partition with other partition formatting.

**How has this been tested?:**
 N/A

Same change as: https://github.com/ansible-lockdown/RHEL9-CIS/pull/152

