### PR TITLE
auth-select options variable not used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     args: ['--baseline-path', '.config/.gitleaks-report.json']
 
 - repo: https://github.com/ansible-community/ansible-lint
-  rev: v6.22.1
+  rev: v6.22.2
   hooks:
   - id: ansible-lint
     name: Ansible-lint

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -620,7 +620,6 @@ rhel9cis_use_authconfig: false
 rhel9cis_authselect:
     custom_profile_name: custom-profile
     default_file_to_copy: "sssd --symlink-meta"
-    options: with-sudo with-faillock without-nullok
 
 # 5.3.1 Enable automation to create custom profile settings, using the settings above
 rhel9cis_authselect_custom_profile_create: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -528,25 +528,29 @@ rhel9cis_auditd:
     space_left_action: email
     action_mail_acct: root
     admin_space_left_action: halt
+    # The max_log_file parameter should be based on your sites policy.
+    max_log_file: 10
     max_log_file_action: keep_logs
+
+# This value governs if the below extra-vars for auditd should be used by the role
+rhel9cis_auditd_extra_conf_usage: false
+
+# This can be used to configure other keys in auditd.conf
+# Example:
+# rhel9cis_auditd_extra_conf:
+#     admin_space_left: '10%'
+rhel9cis_auditd_extra_conf:
+    admin_space_left: 50
+    space_left: 75
 
 # The audit_back_log_limit value should never be below 8192
 rhel9cis_audit_back_log_limit: 8192
-
-# The max_log_file parameter should be based on your sites policy
-rhel9cis_max_log_file_size: 10
 
 ### 4.1.3.x audit template
 update_audit_template: false
 
 ## Advanced option found in auditd post
 rhel9cis_allow_auditd_uid_user_exclusions: false
-
-# This can be used to configure other keys in auditd.conf
-rhel9cis_auditd_extra_conf: {}
-# Example:
-# rhel9cis_auditd_extra_conf:
-#     admin_space_left: '10%'
 
 ## Preferred method of logging
 ## Whether rsyslog or journald preferred method for local logging

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -26,6 +26,19 @@
       - not system_is_container
       - "'procps-ng' in ansible_facts.packages"
 
+- name: POST | Update usr sysctl
+  ansible.builtin.lineinfile:
+      dest: /usr/lib/sysctl.d/50-default.conf
+      regexp: "{{ item.regexp }}"
+      line: "{{ item.line }}"
+  loop:
+      - { regexp: '^net.ipv4.conf.default.rp_filter', line: 'net.ipv4.conf.default.rp_filter = 1' }
+      - { regexp: '^net.ipv4.conf.*.rp_filter', line: 'net.ipv4.conf.*.rp_filter = 1' }
+  when:
+      - rhel9cis_sysctl_update
+      - not system_is_container
+      - "'procps-ng' in ansible_facts.packages"
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -32,7 +32,7 @@
       src: "{{ item.device }}"
       fstype: "{{ item.fstype }}"
       state: present
-      opts: defaults,{% if rhel9cis_rule_1_1_7_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_7_3 %}nosuid,{% endif %}
+      opts: defaults,{% if rhel9cis_rule_1_1_7_2 %}nodev,{% endif %}{% if rhel9cis_rule_1_1_7_3 %}nosuid{% endif %}
   loop: "{{ ansible_facts.mounts }}"
   loop_control:
       label: "{{ item.device }}"

--- a/tasks/section_1/cis_1.3.x.yml
+++ b/tasks/section_1/cis_1.3.x.yml
@@ -67,7 +67,7 @@
         /sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
       validate: aide -D --config %s
   when:
-      - rhel9cis_rule_1_3_2
+      - rhel9cis_rule_1_3_3
       - not system_is_ec2
   tags:
       - level1-server

--- a/tasks/section_1/cis_1.8.x.yml
+++ b/tasks/section_1/cis_1.8.x.yml
@@ -261,4 +261,4 @@
       - level1-workstation
       - patch
       - gui
-      - rule_1.8.4
+      - rule_1.8.10

--- a/tasks/section_4/cis_4.1.2.x.yml
+++ b/tasks/section_4/cis_4.1.2.x.yml
@@ -4,7 +4,7 @@
   ansible.builtin.lineinfile:
       path: /etc/audit/auditd.conf
       regexp: "^max_log_file( |=)"
-      line: "max_log_file = {{ rhel9cis_max_log_file_size }}"
+      line: "max_log_file = {{ rhel9cis_auditd['max_log_file'] }}"
   notify: Restart auditd
   when:
       - rhel9cis_rule_4_1_2_1
@@ -58,6 +58,7 @@
   notify: Restart auditd
   when:
       - rhel9cis_auditd_extra_conf.keys() | length > 0
+      - rhel9cis_auditd_extra_conf_usage
   tags:
       - level2-server
       - level2-workstation

--- a/tasks/section_5/cis_5.4.x.yml
+++ b/tasks/section_5/cis_5.4.x.yml
@@ -43,8 +43,8 @@
                 - "Below are the current custom profiles"
                 - "{{ rhel9cis_5_4_2_profiles_faillock.stdout_lines }}"
 
-      - name: "5.4.2 | PATCH | Ensure authselect includes with-faillock | Create custom profiles"
-        ansible.builtin.shell: "authselect select custom/{{ rhel9cis_authselect['custom_profile_name'] }}  {{ rhel9cis_authselect['options'] }}"
+      - name: "5.4.2 | PATCH | Ensure authselect includes with-faillock | Select custom profile"
+        ansible.builtin.shell: "authselect select custom/{{ rhel9cis_authselect['custom_profile_name'] }} with-faillock"
         when: rhel9cis_authselect_custom_profile_select
 
       - name: 5.4.2 | PATCH | Ensure authselect includes with-faillock | not auth select profile"

--- a/tasks/section_5/cis_5.6.1.x.yml
+++ b/tasks/section_5/cis_5.6.1.x.yml
@@ -12,7 +12,7 @@
       - level1-workstation
       - patch
       - password
-      - rule_5.5.1.1
+      - rule_5.6.1.1
 
 - name: "5.6.1.2 | PATCH | Ensure minimum days between password changes is 7 or more"
   ansible.builtin.lineinfile:
@@ -117,4 +117,4 @@
       - level1-server
       - level1-workstation
       - patch
-      - rule_5.5.1.5
+      - rule_5.6.1.5

--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -98,6 +98,11 @@
             regexp: '^USERGROUPS_ENAB'
             line: USERGROUPS_ENAB no
 
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Force umask sessions /etc/pam.d/system-auth"
+        ansible.builtin.lineinfile:
+            path: /etc/pam.d/system-auth
+            line: 'session     required            pam_umask.so'
+            insertafter: EOF
   when:
       - rhel9cis_rule_5_6_5
   tags:

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -118,7 +118,7 @@
       - level1-workstation
       - patch
       - permissions
-      - rule_6.1.10
+      - rule_6.1.8
 
 - name: "6.1.9 | PATCH | Ensure no world writable files exist"
   block:
@@ -253,7 +253,7 @@
       - patch
       - stickybits
       - permissons
-      - rule_1.1.21
+      - rule_6.1.12
 
 - name: "6.1.13 | AUDIT | Audit SUID executables"
   block:

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -73,7 +73,7 @@
       - audit
       - accounts
       - groups
-      - rule_6.2.2
+      - rule_6.2.3
 
 - name: "6.2.4 | AUDIT Ensure no duplicate UIDs exist"
   block:


### PR DESCRIPTION
**Overall Review of Changes:**
Other OS flavors have [required extra-options](https://www.tenable.com/audits/items/CIS_CentOS_8_Workstation_v2.0.0_L1.audit:0f95080d3c0f472a5ecbf89f99997051) for `authselect` profiles.
Currently, [it seems](https://www.tenable.com/audits/items/CIS_Red_Hat_EL9_v1.0.0_L1_Server.audit:6fe56e3c8fe2179e0086988b2362ffba) this is not needed.

**Issue Fixes:**
#155 

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
N/A
