### PR TITLE
Solving conflicts after previous commit:

### DIFF
--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -98,11 +98,37 @@
             regexp: '^USERGROUPS_ENAB'
             line: USERGROUPS_ENAB no
 
-      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Force umask sessions /etc/pam.d/system-auth"
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Check umask.so in system-auth"
+        shell: |
+            grep -E -q "^session\s*(optional|requisite|required)\s*pam_umask.so$" /etc/pam.d/system-auth
+        ignore_errors: true
+        no_log: true
+        check_mode: true
+        register: pam_umask_line_present_system
+
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in system-auth"
         ansible.builtin.lineinfile:
-            path: /etc/pam.d/system-auth
-            line: 'session     required            pam_umask.so'
-            insertafter: EOF
+            path: "/etc/pam.d/system-auth"
+            regexp: '^session\s*(optional|requisite|required)\s*pam_umask.so$'
+            line: 'session    optional    pam_umask.so'
+        when:
+            - pam_umask_line_present_system.rc | int != 0
+
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Check umask.so in password-auth"
+        shell: |
+            grep -E -q "^session\s*(optional|requisite|required)\s*pam_umask.so$" /etc/pam.d/password-auth
+        ignore_errors: true
+        no_log: true
+        check_mode: true
+        register: pam_umask_line_present_password
+
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in password-auth"
+        ansible.builtin.lineinfile:
+            path: "/etc/pam.d/password-auth"
+            regexp: '^session\s*(optional|requisite|required)\s*pam_umask.so$'
+            line: 'session    optional    pam_umask.so'
+        when:
+            - pam_umask_line_present_password.rc | int != 0
   when:
       - rhel9cis_rule_5_6_5
   tags:

--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -103,7 +103,7 @@
             grep -E -q "^session\s*(optional|requisite|required)\s*pam_umask.so$" /etc/pam.d/system-auth
         ignore_errors: true
         no_log: true
-        check_mode: true
+        check_mode: false
         register: pam_umask_line_present_system
 
       - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in system-auth"
@@ -119,7 +119,7 @@
             grep -E -q "^session\s*(optional|requisite|required)\s*pam_umask.so$" /etc/pam.d/password-auth
         ignore_errors: true
         no_log: true
-        check_mode: true
+        check_mode: false
         register: pam_umask_line_present_password
 
       - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in password-auth"


### PR DESCRIPTION
Recreated [this PR](https://github.com/ansible-lockdown/RHEL9-CIS/pull/163), by cherry-picking previous commit with `--signoff`.

**Overall Review of Changes:**
Conditional insertion of "session optional pam_umask.so" line in:
- `/etc/pam.d/system-auth`
- `/etc/pam.d/password-auth`

**Issue Fixes:**
#162 

**How has this been tested?:**
Manual, on EC2 instance:
```

# cat /etc/pam.d/password-auth  | grep umask
#
# cat /etc/pam.d/system-auth | grep umask
# 
===============================================
TASK [rhel9-cis : 5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Set umask for /etc/login.defs settings] ********************************************************************************************************************************************
ok: [34.244.29.147] => (item={'path': '/etc/bashrc', 'line': 'umask'}) => {"ansible_loop_var": "item", "changed": false, "item": {"line": "umask", "path": "/etc/bashrc"}, "msg": "", "rc": 0}
ok: [34.244.29.147] => (item={'path': '/etc/profile', 'line': 'umask'}) => {"ansible_loop_var": "item", "changed": false, "item": {"line": "umask", "path": "/etc/profile"}, "msg": "", "rc": 0}
ok: [34.244.29.147] => (item={'path': '/etc/login.defs', 'line': 'UMASK'}) => {"ansible_loop_var": "item", "changed": false, "item": {"line": "UMASK", "path": "/etc/login.defs"}, "msg": "", "rc": 0}

TASK [rhel9-cis : 5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Check umask.so in system-auth] *****************************************************************************************************************************************************
fatal: [34.244.29.147]: FAILED! => {"changed": true, "cmd": "grep -E -q \"^session\\s*(optional|requisite|required)\\s*pam_umask.so$\" /etc/pam.d/system-auth\n", "delta": "0:00:00.005307", "end": "2024-01-30 13:50:13.881481", "msg": "non-zero return code", "rc": 1, "start": "2024-01-30 13:50:13.876174", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring

TASK [rhel9-cis : 5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in system-auth] ***********************************************************************************************************************************
changed: [34.244.29.147] => {"backup": "", "changed": true, "msg": "line added"}

TASK [rhel9-cis : 5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Check umask.so in password-auth] ***************************************************************************************************************************************************
fatal: [34.244.29.147]: FAILED! => {"changed": true, "cmd": "grep -E -q \"^session\\s*(optional|requisite|required)\\s*pam_umask.so$\" /etc/pam.d/password-auth\n", "delta": "0:00:00.005221", "end": "2024-01-30 13:50:18.033096", "msg": "non-zero return code", "rc": 1, "start": "2024-01-30 13:50:18.027875", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring

TASK [rhel9-cis : 5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in password-auth] *********************************************************************************************************************************
changed: [34.244.29.147] => {"backup": "", "changed": true, "msg": "line added"}
===============================================


# cat /etc/pam.d/password-auth  | grep umask
session    optional    pam_umask.so
#
# cat /etc/pam.d/system-auth | grep umask
session    optional    pam_umask.so
#
===============================================

CIS_RESULT: pass
"01/30/2024 14:35:06","ip-172-31-38-227.eu-west-1.compute.internal","N/A","N/A","1.0.0","#scap_org.cisecurity_comp_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark-xccdf","CIS Red Hat Enterprise Linux 9 Benchmark","xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark","Level 2 - Server","xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server","xccdf_org.cisecurity.benchmarks_rule_5.6.5_Ensure_default_user_umask_is_027_or_more_restrictive","5.6.5","Ensure default user umask is 027 or more restrictive","pass",","
```