### PR TITLE
Siemens/feat/bgrubby usage for params

### DIFF
--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -34,7 +34,7 @@
       - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby update, if needed"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="audit=1"
         when:
-          - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux | int != 1
+            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux | int != 1
   when:
       - rhel9cis_rule_4_1_1_2
   tags:
@@ -57,7 +57,7 @@
       - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby update, if needed"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"
         when:
-          - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout | int < rhel9cis_audit_back_log_limit
+            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout | int < rhel9cis_audit_back_log_limit
   when:
       - rhel9cis_rule_4_1_1_3
   tags:

--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -24,28 +24,17 @@
 
 - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
   block:
-      - name: "4.1.1.2 | AUDIT | Ensure auditing for processes that start prior to auditd is enabled | Get GRUB_CMDLINE_LINUX"
-        ansible.builtin.shell: grep 'GRUB_CMDLINE_LINUX=' /etc/default/grub | sed 's/.$//'
+      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby existence of current value"
+        ansible.builtin.shell: grubby --info=ALL | grep args | grep -o -E "audit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"
         changed_when: false
         failed_when: false
         check_mode: false
-        register: rhel9cis_4_1_1_2_grub_cmdline_linux
+        register: rhel9cis_4_1_1_2_grubby_curr_value_audit_linux
 
-      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Replace existing setting"
-        ansible.builtin.replace:
-            path: /etc/default/grub
-            regexp: 'audit=.'
-            replace: 'audit=1'
-        notify: Grub2cfg
-        when: "'audit=' in rhel9cis_4_1_1_2_grub_cmdline_linux.stdout"
-
-      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Add audit setting if missing"
-        ansible.builtin.lineinfile:
-            path: /etc/default/grub
-            regexp: '^GRUB_CMDLINE_LINUX='
-            line: '{{ rhel9cis_4_1_1_2_grub_cmdline_linux.stdout }} audit=1"'
-        notify: Grub2cfg
-        when: "'audit=' not in rhel9cis_4_1_1_2_grub_cmdline_linux.stdout"
+      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby update, if needed"
+        ansible.builtin.shell: grubby --update-kernel=ALL --args="audit=1"
+        when:
+          - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux | int != 1
   when:
       - rhel9cis_rule_4_1_1_2
   tags:
@@ -58,28 +47,17 @@
 
 - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient"
   block:
-      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Get GRUB_CMDLINE_LINUX"
-        ansible.builtin.shell: grep 'GRUB_CMDLINE_LINUX=' /etc/default/grub | sed 's/.$//'
+      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby existence of current value"
+        ansible.builtin.shell: grubby --info=ALL | grep args | grep -o -E "audit_backlog_limit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"
         changed_when: false
         failed_when: false
         check_mode: false
-        register: rhel9cis_4_1_1_3_grub_cmdline_linux
+        register: rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux
 
-      - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient | Replace existing setting"
-        ansible.builtin.replace:
-            path: /etc/default/grub
-            regexp: 'audit_backlog_limit=\d+'
-            replace: 'audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}'
-        notify: Grub2cfg
-        when: "'audit_backlog_limit=' in rhel9cis_4_1_1_3_grub_cmdline_linux.stdout"
-
-      - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient | Add audit_backlog_limit setting if missing"
-        ansible.builtin.lineinfile:
-            path: /etc/default/grub
-            regexp: '^GRUB_CMDLINE_LINUX='
-            line: '{{ rhel9cis_4_1_1_3_grub_cmdline_linux.stdout }} audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"'
-        notify: Grub2cfg
-        when: "'audit_backlog_limit=' not in rhel9cis_4_1_1_3_grub_cmdline_linux.stdout"
+      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby update, if needed"
+        ansible.builtin.shell: grubby --update-kernel=ALL --args="audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"
+        when:
+          - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout | int < rhel9cis_audit_back_log_limit
   when:
       - rhel9cis_rule_4_1_1_3
   tags:


### PR DESCRIPTION
Copy of this [PR](https://github.com/ansible-lockdown/RHEL9-CIS/pull/161)

**Overall Review of Changes:**
Grubby instead of `/etc/default/grub`->`/boot/grub2/grub.cfg`

**Issue Fixes:**
#160 

**How has this been tested?:**
On EC2 instance, CIS is happy if `grubby` lists options(`grubby --info=ALL | grep args`) configured previously(`grubby --update-kernel=ALL --args="audit_backlog_limit=8192`)
