### PR TITLE
Update cis_6.1.x.yml

### DIFF
--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -230,7 +230,7 @@
             warn_control_id: '6.1.11'
         when: rhel_09_6_1_11_ungrouped_files_found
   vars:
-      - rhel_09_6_1_11_ungrouped_files_found: false
+      rhel_09_6_1_11_ungrouped_files_found: false
   when:
       - rhel9cis_rule_6_1_11
   tags:


### PR DESCRIPTION
Fixed:
[DEPRECATION WARNING]: Specifying a list of dictionaries for vars is deprecated in favor of specifying a dictionary. This feature will be removed in version 2.18.

**Overall Review of Changes:**
The list of dictionaries is replaced with specifying a dictionary for the task 
`6.1.11 | AUDIT | Ensure no ungrouped files or directories exist`

**Issue Fixes:**
#168 

**How has this been tested?:**
It was tested by playing the task and not receiving a warning.

