### PR TITLE
Rule 5.2.20 expects values different than 0, but previous form of the…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ include:
   - project: 'cybersecurity/automated_hardening_tech/sfera_automation_pipeline'
     # Do not forget to also set the correct pipeline branch below in the first variable!!!
 #    ref: &pipeline_branch master
-    ref: &pipeline_branch 16_extending_oidc_auth
+    ref: &pipeline_branch master
     file: 'pipeline_for_include_ansible.yml'
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 include:
   - project: 'cybersecurity/automated_hardening_tech/sfera_automation_pipeline'
     # Do not forget to also set the correct pipeline branch below in the first variable!!!
-#    ref: &pipeline_branch master
     ref: &pipeline_branch master
     file: 'pipeline_for_include_ansible.yml'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+include:
+  - project: 'cybersecurity/automated_hardening_tech/sfera_automation_pipeline'
+    # Do not forget to also set the correct pipeline branch below in the first variable!!!
+    ref: &pipeline_branch master
+    file: 'pipeline_for_include_ansible.yml'
+
+variables:
+    # Basic data
+    # Require branch of pipeline so as to include correct version of resources
+    PIPELINE_BRANCH: *pipeline_branch
+    BASELINE_FOLDER_NAME: ANSIBLE_CIS_RHEL_9

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
 include:
   - project: 'cybersecurity/automated_hardening_tech/sfera_automation_pipeline'
     # Do not forget to also set the correct pipeline branch below in the first variable!!!
-    ref: &pipeline_branch master
+#    ref: &pipeline_branch master
+    ref: &pipeline_branch 16_extending_oidc_auth
     file: 'pipeline_for_include_ansible.yml'
 
 variables:

--- a/.scapolite_tests.yml
+++ b/.scapolite_tests.yml
@@ -3,214 +3,228 @@ os_image: rhel
 os_image_version: v9
 ciscat_version: v4.33.0
 testruns:
-- name: L2_Server_CIS_RHEL9_Ansible
-  testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server
-  testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
-  testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
-  testrun_ansible_vars:
-    ubtu22cis_sshd:
-      allow_users: "ec2-user"
-      allow_groups: "sshadmins"
-  testrun_ansible_tags:
-  - level2-server
-  - level1-server
-  testrun_skip_ansible_tags:
-  - rule_5.3.4 # Enforcing password-based escalation will be disruptive for our AWS automation
-  activities:
-  # - id: 20_Ansible_Role_InitialCheck_L2_Workstation
-  #   type: ansible
-  #   role_name: rhel9-cis # code.siemens.com
-  #   ansible:
-  #     check_mode: yes
-  - id: 21_initial_ciscat_check
-    type: ciscat
-    validations:
-    - sub_type: count
-      expected:
-        pass: 134
-        fail: 97
-        error: 0
-        unknown: 0
-        not selected: 24
-    - sub_type: by_id
-      result: pass
-      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_4, R1_2_2, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_4_2_1, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_18, R5_2_20, R5_3_1, R5_3_5, R5_3_6, R5_5_4, R5_6_1_3, R5_6_1_5, R5_6_2, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
-    - sub_type: by_id
-      result: fail
-      check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_6, R1_7_2, R1_7_3, R2_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_1_1_2, R4_1_1_3, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_2_1_4, R4_2_2_3, R4_2_2_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_4, R5_2_7, R5_2_12, R5_2_13, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_3_2, R5_3_3, R5_3_4, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3, R5_6_5, R5_6_6, R6_2_2]
-  - id: 22_Ansible_Role_Implement_L2_Workstation
-    type: ansible
-    role_name: "rhel9-cis"
-    before_script: |
-      /sbin/groupadd sshadmins
-      /sbin/usermod -a -G sshadmins ec2-user
-  - id: 23_ciscat_check_after_implement
-    type: ciscat
-    validations:
-    - sub_type: count
-      expected:
-        pass: 212
-        fail: 19
-        error: 0
-        unknown: 0
-        not selected: 24
-    - sub_type: compare
-      compare_with: 21_initial_ciscat_check
-      overall_expected_change: improvement
-      expected:
-        rules_passed_only_here: &rulesPassedOnlyAfterImplementL2 [R1_1_1_1, R1_1_1_2, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_7_2, R1_7_3, R2_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_2, R4_1_3_20, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_2_1_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_13, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_2_7, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3]
-        rules_failed_only_there: *rulesPassedOnlyAfterImplementL2
-        rules_passed_only_there: &rulesFAILEDAfterImplementL2 [R5_2_20]
-        rules_failed_only_here: *rulesFAILEDAfterImplementL2
-        rules_unknown_only_here: []
-        rules_unknown_only_there: []
-    - sub_type: by_id
-      result: pass
-      check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R4_2_3, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_13, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
-    - sub_type: by_id
-      result: fail
-      check_ids: [R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_6_1_6, R3_3_7, R4_1_1_2, R4_1_1_3, R4_2_2_3, R4_2_2_4, R5_2_4, R5_2_12, R5_2_20, R5_3_4, R5_6_5, R5_6_6, R6_2_2]
-  - id: 25_reboot_system_for_testing_consistency
-    type: reboot
-    args:
-    - msg: "Reboot performed as requested on testfiles used for running ANSIBLE_CIS_DEBIAN_10 pipeline(L2)"
-    - test_command: "uptime -s"
-    - reboot_timeout: 100
-  # - id: 24_Ansible_Role_CheckAfterImplement_L1_Workstation
-  #   type: ansible
-  #   role_name: "rhel9-cis"
-  #   before_script: |
-  #     cat /etc/os-release
-  #   ansible:
-  #     check_mode: yes
-  #     diff: yes
-  - id: 26_ciscat_check_after_impl_AND_reboot
-    type: ciscat
-    validations:
-    - sub_type: count
-      expected:
-        pass: 211
-        fail: 20
-        error: 0
-        unknown: 0
-        not selected: 24
-    - sub_type: compare
-      compare_with: 23_ciscat_check_after_implement
-      overall_expected_change: stagnation
-      expected:
-        rules_passed_only_here: []
-        rules_failed_only_there: []
-        rules_passed_only_there: [R4_2_3]
-        rules_failed_only_here: [R4_2_3]
-        rules_unknown_only_here: []
-        rules_unknown_only_there: []
-    - sub_type: by_id
-      result: pass
-      check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_13, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
-    - sub_type: by_id
-      check_ids: [R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_6_1_6, R3_3_7, R4_1_1_2, R4_1_1_3, R4_2_2_3, R4_2_2_4, R4_2_3, R5_2_4, R5_2_12, R5_2_20, R5_3_4, R5_6_5, R5_6_6, R6_2_2]
-      result: fail
+    - name: L2_Server_CIS_RHEL9_Ansible
+      testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server
+      testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
+      testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
+      testrun_ansible_vars:
+          ubtu22cis_sshd:
+              allow_users: "ec2-user"
+              allow_groups: "sshadmins"
+      testrun_ansible_tags:
+          - level2-server
+          - level1-server
+      testrun_skip_ansible_tags:
+          - rule_5.3.4 # Enforcing password-based escalation will be disruptive for our AWS automation
+      activities:
+          # - id: 20_Ansible_Role_InitialCheck_L2_Workstation
+          #   type: ansible
+          #   role_name: rhel9-cis # code.siemens.com
+          #   ansible:
+          #     check_mode: yes
+          - id: 21_initial_ciscat_check
+            type: ciscat
+            validations:
+            - sub_type: count
+              expected:
+                  pass: 134
+                  fail: 97
+                  not selected: 24
+            - sub_type: by_id
+              result: pass
+              check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_4, R1_2_2, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_4_2_1, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_18, R5_2_20, R5_3_1, R5_3_5, R5_3_6, R5_5_4, R5_6_1_3, R5_6_1_5, R5_6_2, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+            - sub_type: by_id
+              result: fail
+              check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_6, R1_7_2, R1_7_3, R2_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_1_1_2, R4_1_1_3, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_2_1_4, R4_2_2_3, R4_2_2_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_4, R5_2_7, R5_2_12, R5_2_13, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_3_2, R5_3_3, R5_3_4, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3, R5_6_5, R5_6_6, R6_2_2]
+          - id: 22_Ansible_Role_Implement_L2_Workstation
+            type: ansible
+            role_name: "rhel9-cis"
+            before_script: |
+                /sbin/groupadd sshadmins
+                /sbin/usermod -a -G sshadmins ec2-user
+          - id: 23_ciscat_check_after_implement
+            type: ciscat
+            validations:
+            - sub_type: count
+              expected:
+                  pass: 213
+                  fail: 18
+                  not selected: 24
+            - sub_type: compare
+              compare_with: 21_initial_ciscat_check
+              overall_expected_change: improvement
+              expected:
+                rules_passed_only_here: [R1_1_1_1, R1_1_1_2, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_7_2, R1_7_3, R2_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_2, R4_1_3_20, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_2_1_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_13, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_2_7, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3]
+                rules_failed_only_here: &rulesFAILEDAfterImplementL2
+                    - R5_2_20 # [TBD] Ensure SSH Idle Timeout Interval is configured
+                rules_unknown_only_there: []
+            - sub_type: by_id
+              result: pass
+              check_ids: &passed_rules_after_impl_l2 [R1_1_1_1, R1_1_1_2, R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R4_2_3, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_13, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+            - sub_type: by_id
+              result: fail
+              check_ids: &failed_rules_after_impl_l2
+                  - R1_1_2_1 # [N/A]                                            Ensure /tmp is a separate partition
+                  - R1_1_3_1 # [N/A]                                            Ensure separate partition exists for /var
+                  - R1_1_4_1 # [N/A]                                            Ensure separate partition exists for /var/tmp
+                  - R1_1_5_1 # [N/A]                                            Ensure separate partition exists for /var/log
+                  - R1_1_6_1 # [N/A]                                            Ensure separate partition exists for /var/log/audit
+                  - R1_1_7_1 # [N/A]                                            Ensure separate partition exists for /home
+                  - R1_6_1_6 # [ SSM ]                                          Ensure no unconfined services exist
+                  - R4_1_1_2 # [Grub audit=1]                                   Ensure auditing for processes that start prior to auditd is enabled
+                  - R4_1_1_3 # [Grub audit_backlog_limit]                       Ensure audit_backlog_limit is sufficient
+                  - R4_2_2_3 # [Compress in /etc/systemd/journald.conf]         Ensure journald is configured to compress large log files
+                  - R4_2_2_4 # [Storage=persistent /etc/systemd/journald.conf]  Ensure journald is configured to write logfiles to persistent disk
+                  - R5_2_4   # [TBD]                                            Ensure SSH access is limited
+                  - R5_2_12  #                                                  Ensure SSH X11 forwarding is disabled
+                  - R5_2_20  #                                                  Ensure SSH Idle Timeout Interval is configured
+                  - R5_3_4   # [DELIBERATELY IMPL-SKIPPED]                      Ensure users must provide password for escalation
+                  - R5_6_5   # Ensure default user umask is 027 or more restrictive
+                  - R5_6_6   # Ensure root password is set
+                  - R6_2_2   # Ensure /etc/shadow password fields are not empty
+          - id: 25_reboot_system_for_testing_consistency
+            type: reboot
+            args:
+                - msg: "Reboot performed as requested on testfiles used for running ANSIBLE_CIS_DEBIAN_10 pipeline(L2)"
+                - test_command: "chmod g-wx,o-rwx /var/log/chrony/tracking.log" # Without adjusting log-perm during reboot, R4_2_3 will be reported as Fail
+                - reboot_timeout: 100
+          # - id: 24_Ansible_Role_CheckAfterImplement_L1_Workstation
+          #   type: ansible
+          #   role_name: "rhel9-cis"
+          #   before_script: |
+          #     cat /etc/os-release
+          #   ansible:
+          #     check_mode: yes
+          #     diff: yes
+          - id: 26_ciscat_check_after_impl_AND_reboot
+            type: ciscat
+            validations:
+                - sub_type: count
+                  expected:
+                      pass: 213
+                      fail: 18
+                      error: 0
+                      unknown: 0
+                      not selected: 24
+                - sub_type: compare
+                  compare_with: 23_ciscat_check_after_implement
+                  overall_expected_change: stagnation
+                  expected:
+                      rules_passed_only_here:  []
+                      rules_failed_only_here:  [] # - R4_2_3 # Ensure all logfiles have appropriate permissions and ownership
+                      rules_unknown_only_here: []
+                - sub_type: by_id
+                  result: pass
+                  check_ids: *passed_rules_after_impl_l2
+                - sub_type: by_id
+                  check_ids: *failed_rules_after_impl_l2
+                  result: fail
 
-- name: L1_Server_CIS_RHEL9_Ansible
-  testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
-  testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
-  testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
-  testrun_ansible_vars:
-    rhel9cis_sshd:
-      allow_users: "ec2-user"
-      allow_groups: "sshadmins"
-  testrun_ansible_tags:
-  - level1-server
-  activities:
-  - id: 10_Ansible_Role_InitialCheck_L1_Workstation
-    type: ansible
-    role_name: rhel9-cis # code.siemens.com
-    ansible:
-      check_mode: yes
-  - id: 11_initial_ciscat_check
-    type: ciscat
-    validations:
-    - sub_type: count
-      expected:
-        pass: 119
-        fail: 62
-        error: 0
-        unknown: 0
-        not selected: 74
-    - sub_type: by_id
-      result: pass
-      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_4, R1_2_2, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_4_2_1, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_18, R5_2_20, R5_3_1, R5_3_5, R5_3_6, R5_5_4, R5_6_1_3, R5_6_1_5, R5_6_2, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
-    - sub_type: by_id
-      result: fail
-      check_ids: [R1_1_2_1, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_6, R1_7_2, R1_7_3, R2_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_2_1_4, R4_2_2_3, R4_2_2_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_4, R5_2_7, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3, R5_6_5, R5_6_6, R6_2_2]
-  - id: 12_Ansible_Role_Implement_L1_Workstation
-    type: ansible
-    role_name: rhel9-cis # code.siemens.com
-    before_script: |
-      /sbin/groupadd sshadmins
-      /sbin/usermod -a -G sshadmins ec2-user
-  - id: 13_ciscat_check_after_implement
-    type: ciscat
-    validations:
-    - sub_type: count
-      expected:
-        pass: 171
-        fail: 10
-        error: 0
-        unknown: 0
-        not selected: 74
-    - sub_type: compare
-      compare_with: 11_initial_ciscat_check
-      overall_expected_change: improvement
-      expected:
-        rules_passed_only_here: &rulesPassedOnlyAfterImplementL1 [R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_7_2, R1_7_3, R2_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_2_1_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_2_7, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3]
-        rules_failed_only_there: *rulesPassedOnlyAfterImplementL1
-        rules_passed_only_there: [R5_2_20]
-        rules_failed_only_here: [R5_2_20]
-        rules_unknown_only_here: []
-        rules_unknown_only_there: []
-    - sub_type: by_id
-      result: pass
-      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R4_2_3, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
-    - sub_type: by_id
-      result: fail
-      check_ids: [R1_1_2_1, R1_6_1_6, R3_3_7, R4_2_2_3, R4_2_2_4, R5_2_4, R5_2_20, R5_6_5, R5_6_6, R6_2_2]
-  - id: 15_reboot_system_for_testing_consistency
-    type: reboot
-    args:
-    - msg: Reboot performed as requested on testfiles used for running ANSIBLE_CIS_DEBIAN_10 pipeline(L1)
-    - reboot_timeout: 100
-    # - id: 14_Ansible_Role_CheckAfterImplement_L1_Workstation
-  #   type: ansible
-  #   role_name: rhel9-cis # code.siemens.com
-  #   before_script: |
-  #     cat /etc/os-release
-  #   ansible:
-  #     check_mode: yes
-  #     diff: yes
-  - id: 16_ciscat_check_after_impl_AND_reboot
-    type: ciscat
-    validations:
-    - sub_type: count
-      expected:
-        pass: 170
-        fail: 11
-        error: 0
-        unknown: 0
-        not selected: 74
-    - sub_type: compare
-      compare_with: 13_ciscat_check_after_implement
-      overall_expected_change: stagnation
-      expected:
-        rules_passed_only_here: []
-        rules_failed_only_there: []
-        rules_passed_only_there: [R4_2_3]
-        rules_failed_only_here: [R4_2_3]
-        rules_unknown_only_here: []
-        rules_unknown_only_there: []
-    - sub_type: by_id
-      result: pass
-      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
-    - sub_type: by_id
-      result: fail
-      check_ids: [R1_1_2_1, R1_6_1_6, R3_3_7, R4_2_2_3, R4_2_2_4, R4_2_3, R5_2_4, R5_2_20, R5_6_5, R5_6_6, R6_2_2]
+    - name: L1_Server_CIS_RHEL9_Ansible
+      testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
+      testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
+      testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
+      testrun_ansible_vars:
+        rhel9cis_sshd:
+          allow_users: "ec2-user"
+          allow_groups: "sshadmins"
+      testrun_ansible_tags:
+      - level1-server
+      activities:
+#      - id: 10_Ansible_Role_InitialCheck_L1_Workstation
+#        type: ansible
+#        role_name: rhel9-cis     # code.siemens.com
+#        ansible:
+#          check_mode: yes
+      - id: 11_initial_ciscat_check
+        type: ciscat
+        validations:
+        - sub_type: count
+          expected:
+              pass: 119
+              fail: 62
+              error: 0
+              unknown: 0
+              not selected: 74
+        - sub_type: by_id
+          result: pass
+          check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_4, R1_2_2, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_4_2_1, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_18, R5_2_20, R5_3_1, R5_3_5, R5_3_6, R5_5_4, R5_6_1_3, R5_6_1_5, R5_6_2, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+        - sub_type: by_id
+          result: fail
+          check_ids: [R1_1_2_1, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_6, R1_7_2, R1_7_3, R2_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_2_1_4, R4_2_2_3, R4_2_2_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_4, R5_2_7, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3, R5_6_5, R5_6_6, R6_2_2]
+      - id: 12_Ansible_Role_Implement_L1_Workstation
+        type: ansible
+        role_name: rhel9-cis     # code.siemens.com
+        before_script: |
+            /sbin/groupadd sshadmins
+            /sbin/usermod -a -G sshadmins ec2-user
+      - id: 13_ciscat_check_after_implement
+        type: ciscat
+        validations:
+        - sub_type: count
+          expected:
+              pass: 172
+              fail: 9
+              error: 0
+              unknown: 0
+              not selected: 74
+        - sub_type: compare
+          compare_with: 11_initial_ciscat_check
+          overall_expected_change: improvement
+          expected:
+              rules_passed_only_here: [R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_7_2, R1_7_3, R2_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_2_1_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_2_7, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3]
+              rules_passed_only_there:
+              - R5_2_20
+              rules_unknown_only_here: []
+        - sub_type: by_id
+          result: pass
+          check_ids: &passed_rules_after_impl_l1 [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R4_2_3, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+        - sub_type: by_id
+          result: fail
+          check_ids: &failed_rules_after_impl_l1
+              - R1_1_2_1         # [N/A]                                            Ensure /tmp is a separate partition
+              - R1_6_1_6         # [ SSM ]                                          Ensure no unconfined services exist
+              - R4_2_2_3         # [Compress in /etc/systemd/journald.conf]         Ensure journald is configured to compress large log files
+              - R4_2_2_4         # [Storage=persistent /etc/systemd/journald.conf]  Ensure journald is configured to write logfiles to persistent disk
+              - R5_2_4           # [TBD]                                            Ensure SSH access is limited
+              - R5_2_20          # #                                                Ensure SSH Idle Timeout Interval is configured
+              - R5_6_5           # Ensure default user umask is 027 or more restrictive
+              - R5_6_6           # Ensure root password is set
+              - R6_2_2           # Ensure /etc/shadow password fields are not empty
+      - id: 15_reboot_system_for_testing_consistency
+        type: reboot
+        args:
+        - msg: Reboot performed as requested on testfiles used for running ANSIBLE_CIS_DEBIAN_10 pipeline(L1)
+        - reboot_timeout: 100
+        - test_command: "chmod g-wx,o-rwx /var/log/chrony/tracking.log" # Fixing rule: "R4_2_3-Ensure all logfiles have appropriate permissions and ownership"
+          # - id: 14_Ansible_Role_CheckAfterImplement_L1_Workstation
+          #   type: ansible
+          #   role_name: rhel9-cis # code.siemens.com
+          #   before_script: |
+          #     cat /etc/os-release
+          #   ansible:
+          #     check_mode: yes
+          #     diff: yes
+      - id: 16_ciscat_check_after_impl_AND_reboot
+        type: ciscat
+        validations:
+        - sub_type: count
+          expected:
+              pass: 172
+              fail: 9
+              error: 0
+              unknown: 0
+              not selected: 74
+        - sub_type: compare
+          compare_with: 13_ciscat_check_after_implement
+          overall_expected_change: stagnation
+          expected:
+              rules_passed_only_here: []
+              rules_failed_only_here: []
+              rules_unknown_only_here: []
+        - sub_type: by_id
+          result: pass
+          check_ids: *passed_rules_after_impl_l1
+        - sub_type: by_id
+          result: fail
+          check_ids: *failed_rules_after_impl_l1

--- a/.scapolite_tests.yml
+++ b/.scapolite_tests.yml
@@ -3,7 +3,6 @@ os_image: rhel
 os_image_version: v9
 ciscat_version: v4.33.0
 testruns:
-<<<<<<< HEAD
 - name: L2_Server_CIS_RHEL9_Ansible
   testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server
   testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
@@ -112,8 +111,6 @@ testruns:
       check_ids: [R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_6_1_6, R3_3_7, R4_1_1_2, R4_1_1_3, R4_2_2_3, R4_2_2_4, R4_2_3, R5_2_4, R5_2_12, R5_2_20, R5_3_4, R5_6_5, R5_6_6, R6_2_2]
       result: fail
 
-=======
->>>>>>> dfffb19 (Adding testfile with L1.)
 - name: L1_Server_CIS_RHEL9_Ansible
   testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
   testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml

--- a/.scapolite_tests.yml
+++ b/.scapolite_tests.yml
@@ -3,6 +3,7 @@ os_image: rhel
 os_image_version: v9
 ciscat_version: v4.33.0
 testruns:
+<<<<<<< HEAD
 - name: L2_Server_CIS_RHEL9_Ansible
   testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server
   testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
@@ -111,6 +112,8 @@ testruns:
       check_ids: [R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_6_1_6, R3_3_7, R4_1_1_2, R4_1_1_3, R4_2_2_3, R4_2_2_4, R4_2_3, R5_2_4, R5_2_12, R5_2_20, R5_3_4, R5_6_5, R5_6_6, R6_2_2]
       result: fail
 
+=======
+>>>>>>> dfffb19 (Adding testfile with L1.)
 - name: L1_Server_CIS_RHEL9_Ansible
   testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
   testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml

--- a/.scapolite_tests.yml
+++ b/.scapolite_tests.yml
@@ -3,6 +3,114 @@ os_image: rhel
 os_image_version: v9
 ciscat_version: v4.33.0
 testruns:
+- name: L2_Server_CIS_RHEL9_Ansible
+  testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_2_-_Server
+  testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
+  testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
+  testrun_ansible_vars:
+    ubtu22cis_sshd:
+      allow_users: "ec2-user"
+      allow_groups: "sshadmins"
+  testrun_ansible_tags:
+  - level2-server
+  - level1-server
+  testrun_skip_ansible_tags:
+  - rule_5.3.4 # Enforcing password-based escalation will be disruptive for our AWS automation
+  activities:
+  # - id: 20_Ansible_Role_InitialCheck_L2_Workstation
+  #   type: ansible
+  #   role_name: rhel9-cis # code.siemens.com
+  #   ansible:
+  #     check_mode: yes
+  - id: 21_initial_ciscat_check
+    type: ciscat
+    validations:
+    - sub_type: count
+      expected:
+        pass: 134
+        fail: 97
+        error: 0
+        unknown: 0
+        not selected: 24
+    - sub_type: by_id
+      result: pass
+      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_4, R1_2_2, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_4_2_1, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_18, R5_2_20, R5_3_1, R5_3_5, R5_3_6, R5_5_4, R5_6_1_3, R5_6_1_5, R5_6_2, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+    - sub_type: by_id
+      result: fail
+      check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_6, R1_7_2, R1_7_3, R2_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_1_1_2, R4_1_1_3, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_2_1_4, R4_2_2_3, R4_2_2_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_4, R5_2_7, R5_2_12, R5_2_13, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_3_2, R5_3_3, R5_3_4, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3, R5_6_5, R5_6_6, R6_2_2]
+  - id: 22_Ansible_Role_Implement_L2_Workstation
+    type: ansible
+    role_name: "rhel9-cis"
+    before_script: |
+      /sbin/groupadd sshadmins
+      /sbin/usermod -a -G sshadmins ec2-user
+  - id: 23_ciscat_check_after_implement
+    type: ciscat
+    validations:
+    - sub_type: count
+      expected:
+        pass: 212
+        fail: 19
+        error: 0
+        unknown: 0
+        not selected: 24
+    - sub_type: compare
+      compare_with: 21_initial_ciscat_check
+      overall_expected_change: improvement
+      expected:
+        rules_passed_only_here: &rulesPassedOnlyAfterImplementL2 [R1_1_1_1, R1_1_1_2, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_7_2, R1_7_3, R2_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_2, R4_1_3_20, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_2_1_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_13, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_2_7, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3]
+        rules_failed_only_there: *rulesPassedOnlyAfterImplementL2
+        rules_passed_only_there: &rulesFAILEDAfterImplementL2 [R5_2_20]
+        rules_failed_only_here: *rulesFAILEDAfterImplementL2
+        rules_unknown_only_here: []
+        rules_unknown_only_there: []
+    - sub_type: by_id
+      result: pass
+      check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R4_2_3, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_13, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+    - sub_type: by_id
+      result: fail
+      check_ids: [R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_6_1_6, R3_3_7, R4_1_1_2, R4_1_1_3, R4_2_2_3, R4_2_2_4, R5_2_4, R5_2_12, R5_2_20, R5_3_4, R5_6_5, R5_6_6, R6_2_2]
+  - id: 25_reboot_system_for_testing_consistency
+    type: reboot
+    args:
+    - msg: "Reboot performed as requested on testfiles used for running ANSIBLE_CIS_DEBIAN_10 pipeline(L2)"
+    - test_command: "uptime -s"
+    - reboot_timeout: 100
+  # - id: 24_Ansible_Role_CheckAfterImplement_L1_Workstation
+  #   type: ansible
+  #   role_name: "rhel9-cis"
+  #   before_script: |
+  #     cat /etc/os-release
+  #   ansible:
+  #     check_mode: yes
+  #     diff: yes
+  - id: 26_ciscat_check_after_impl_AND_reboot
+    type: ciscat
+    validations:
+    - sub_type: count
+      expected:
+        pass: 211
+        fail: 20
+        error: 0
+        unknown: 0
+        not selected: 24
+    - sub_type: compare
+      compare_with: 23_ciscat_check_after_implement
+      overall_expected_change: stagnation
+      expected:
+        rules_passed_only_here: []
+        rules_failed_only_there: []
+        rules_passed_only_there: [R4_2_3]
+        rules_failed_only_here: [R4_2_3]
+        rules_unknown_only_here: []
+        rules_unknown_only_there: []
+    - sub_type: by_id
+      result: pass
+      check_ids: [R1_1_1_1, R1_1_1_2, R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_5, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_1, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_1_3, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_1_1_1, R4_1_1_4, R4_1_2_1, R4_1_2_2, R4_1_2_3, R4_1_3_1, R4_1_3_2, R4_1_3_3, R4_1_3_4, R4_1_3_5, R4_1_3_6, R4_1_3_7, R4_1_3_8, R4_1_3_9, R4_1_3_10, R4_1_3_11, R4_1_3_12, R4_1_3_13, R4_1_3_14, R4_1_3_15, R4_1_3_16, R4_1_3_17, R4_1_3_18, R4_1_3_19, R4_1_3_20, R4_1_4_1, R4_1_4_2, R4_1_4_3, R4_1_4_4, R4_1_4_5, R4_1_4_7, R4_1_4_8, R4_1_4_9, R4_1_4_10, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_13, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+    - sub_type: by_id
+      check_ids: [R1_1_2_1, R1_1_3_1, R1_1_4_1, R1_1_5_1, R1_1_6_1, R1_1_7_1, R1_6_1_6, R3_3_7, R4_1_1_2, R4_1_1_3, R4_2_2_3, R4_2_2_4, R4_2_3, R5_2_4, R5_2_12, R5_2_20, R5_3_4, R5_6_5, R5_6_6, R6_2_2]
+      result: fail
+
 - name: L1_Server_CIS_RHEL9_Ansible
   testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
   testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml

--- a/.scapolite_tests.yml
+++ b/.scapolite_tests.yml
@@ -8,7 +8,7 @@ testruns:
   testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
   testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
   testrun_ansible_vars:
-    ubtu22cis_sshd:
+    rhel9cis_sshd:
       allow_users: "ec2-user"
       allow_groups: "sshadmins"
   testrun_ansible_tags:

--- a/.scapolite_tests.yml
+++ b/.scapolite_tests.yml
@@ -1,0 +1,108 @@
+os_family: unix
+os_image: rhel
+os_image_version: v9
+ciscat_version: v4.33.0
+testruns:
+- name: L1_Server_CIS_RHEL9_Ansible
+  testrun_ciscat_profile: xccdf_org.cisecurity.benchmarks_profile_Level_1_-_Server
+  testrun_benchmark_filename: CIS_Red_Hat_Enterprise_Linux_9_Benchmark_v1.0.0-xccdf.xml
+  testrun_checklist_id: "xccdf_org.cisecurity.benchmarks_benchmark_1.0.0_CIS_Red_Hat_Enterprise_Linux_9_Benchmark"
+  testrun_ansible_vars:
+    ubtu22cis_sshd:
+      allow_users: "ec2-user"
+      allow_groups: "sshadmins"
+  testrun_ansible_tags:
+  - level1-server
+  activities:
+  - id: 10_Ansible_Role_InitialCheck_L1_Workstation
+    type: ansible
+    role_name: rhel9-cis # code.siemens.com
+    ansible:
+      check_mode: yes
+  - id: 11_initial_ciscat_check
+    type: ciscat
+    validations:
+    - sub_type: count
+      expected:
+        pass: 119
+        fail: 62
+        error: 0
+        unknown: 0
+        not selected: 74
+    - sub_type: by_id
+      result: pass
+      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_4, R1_2_2, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_4_2_1, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_18, R5_2_20, R5_3_1, R5_3_5, R5_3_6, R5_5_4, R5_6_1_3, R5_6_1_5, R5_6_2, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+    - sub_type: by_id
+      result: fail
+      check_ids: [R1_1_2_1, R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_6, R1_7_2, R1_7_3, R2_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_7, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_2_1_4, R4_2_2_3, R4_2_2_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_4, R5_2_7, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3, R5_6_5, R5_6_6, R6_2_2]
+  - id: 12_Ansible_Role_Implement_L1_Workstation
+    type: ansible
+    role_name: rhel9-cis # code.siemens.com
+    before_script: |
+      /sbin/groupadd sshadmins
+      /sbin/usermod -a -G sshadmins ec2-user
+  - id: 13_ciscat_check_after_implement
+    type: ciscat
+    validations:
+    - sub_type: count
+      expected:
+        pass: 171
+        fail: 10
+        error: 0
+        unknown: 0
+        not selected: 74
+    - sub_type: compare
+      compare_with: 11_initial_ciscat_check
+      overall_expected_change: improvement
+      expected:
+        rules_passed_only_here: &rulesPassedOnlyAfterImplementL1 [R1_1_8_3, R1_1_9, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_7_2, R1_7_3, R2_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_2, R3_4_2_3, R3_4_2_4, R4_2_1_4, R4_2_3, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_2_15, R5_2_16, R5_2_17, R5_2_19, R5_2_7, R5_3_2, R5_3_3, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_6_1_1, R5_6_1_2, R5_6_1_4, R5_6_3]
+        rules_failed_only_there: *rulesPassedOnlyAfterImplementL1
+        rules_passed_only_there: [R5_2_20]
+        rules_failed_only_here: [R5_2_20]
+        rules_unknown_only_here: []
+        rules_unknown_only_there: []
+    - sub_type: by_id
+      result: pass
+      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R4_2_3, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+    - sub_type: by_id
+      result: fail
+      check_ids: [R1_1_2_1, R1_6_1_6, R3_3_7, R4_2_2_3, R4_2_2_4, R5_2_4, R5_2_20, R5_6_5, R5_6_6, R6_2_2]
+  - id: 15_reboot_system_for_testing_consistency
+    type: reboot
+    args:
+    - msg: Reboot performed as requested on testfiles used for running ANSIBLE_CIS_DEBIAN_10 pipeline(L1)
+    - reboot_timeout: 100
+    # - id: 14_Ansible_Role_CheckAfterImplement_L1_Workstation
+  #   type: ansible
+  #   role_name: rhel9-cis # code.siemens.com
+  #   before_script: |
+  #     cat /etc/os-release
+  #   ansible:
+  #     check_mode: yes
+  #     diff: yes
+  - id: 16_ciscat_check_after_impl_AND_reboot
+    type: ciscat
+    validations:
+    - sub_type: count
+      expected:
+        pass: 170
+        fail: 11
+        error: 0
+        unknown: 0
+        not selected: 74
+    - sub_type: compare
+      compare_with: 13_ciscat_check_after_implement
+      overall_expected_change: stagnation
+      expected:
+        rules_passed_only_here: []
+        rules_failed_only_there: []
+        rules_passed_only_there: [R4_2_3]
+        rules_failed_only_here: [R4_2_3]
+        rules_unknown_only_here: []
+        rules_unknown_only_there: []
+    - sub_type: by_id
+      result: pass
+      check_ids: [R1_1_2_2, R1_1_2_3, R1_1_2_4, R1_1_3_2, R1_1_3_3, R1_1_4_2, R1_1_4_3, R1_1_4_4, R1_1_5_2, R1_1_5_3, R1_1_5_4, R1_1_6_2, R1_1_6_3, R1_1_6_4, R1_1_7_2, R1_1_7_3, R1_1_8_1, R1_1_8_2, R1_1_8_3, R1_1_8_4, R1_1_9, R1_2_2, R1_3_1, R1_3_2, R1_3_3, R1_4_1, R1_4_2, R1_5_1, R1_5_2, R1_5_3, R1_6_1_1, R1_6_1_2, R1_6_1_3, R1_6_1_4, R1_6_1_7, R1_6_1_8, R1_7_1, R1_7_2, R1_7_3, R1_7_4, R1_7_5, R1_7_6, R1_8_2, R1_8_3, R1_8_4, R1_8_5, R1_8_6, R1_8_7, R1_8_8, R1_8_9, R1_8_10, R1_10, R2_1_1, R2_1_2, R2_2_2, R2_2_3, R2_2_4, R2_2_5, R2_2_6, R2_2_7, R2_2_8, R2_2_9, R2_2_10, R2_2_11, R2_2_12, R2_2_13, R2_2_14, R2_2_15, R2_2_16, R2_2_17, R2_2_18, R2_3_1, R2_3_2, R2_3_3, R2_3_4, R3_1_2, R3_2_1, R3_2_2, R3_3_1, R3_3_2, R3_3_3, R3_3_4, R3_3_5, R3_3_6, R3_3_8, R3_3_9, R3_4_1_1, R3_4_1_2, R3_4_2_1, R3_4_2_2, R3_4_2_3, R3_4_2_4, R3_4_2_7, R4_2_1_1, R4_2_1_2, R4_2_1_4, R4_2_1_7, R4_2_2_1_4, R4_2_2_2, R5_1_1, R5_1_2, R5_1_3, R5_1_4, R5_1_5, R5_1_6, R5_1_7, R5_1_8, R5_1_9, R5_2_1, R5_2_2, R5_2_3, R5_2_5, R5_2_6, R5_2_7, R5_2_8, R5_2_9, R5_2_10, R5_2_11, R5_2_14, R5_2_15, R5_2_16, R5_2_17, R5_2_18, R5_2_19, R5_3_1, R5_3_2, R5_3_3, R5_3_5, R5_3_6, R5_3_7, R5_4_2, R5_5_1, R5_5_2, R5_5_3, R5_5_4, R5_6_1_1, R5_6_1_2, R5_6_1_3, R5_6_1_4, R5_6_1_5, R5_6_2, R5_6_3, R5_6_4, R6_1_1, R6_1_2, R6_1_3, R6_1_4, R6_1_5, R6_1_6, R6_1_7, R6_1_8, R6_1_9, R6_1_10, R6_1_11, R6_1_12, R6_2_1, R6_2_3, R6_2_4, R6_2_5, R6_2_6, R6_2_7, R6_2_8, R6_2_9, R6_2_10, R6_2_11, R6_2_12, R6_2_13, R6_2_14, R6_2_15, R6_2_16]
+    - sub_type: by_id
+      result: fail
+      check_ids: [R1_1_2_1, R1_6_1_6, R3_3_7, R4_2_2_3, R4_2_2_4, R4_2_3, R5_2_4, R5_2_20, R5_6_5, R5_6_6, R6_2_2]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1024,7 +1024,7 @@ rhel9cis_sshd:
     # This variable sets the maximum number of unresponsive "keep-alive" messages
     # that can be sent from the server to the client before the connection is considered
     # inactive and thus, closed.
-    clientalivecountmax: 0
+    clientalivecountmax: 3
     # This variable sets the time interval in seconds between sending "keep-alive"
     # messages from the server to the client. These types of messages are intended to
     # keep the connection alive and prevent it being terminated due to inactivity.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,7 @@
 ---
 # defaults file for rhel9-cis
-# WARNING:
-# These values may be overriden by other vars-setting options(e.g. like the below 'container_vars_file'), as explained here:
-# https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable
 
-## Usage on containerized images
-# The role discovers dynamically (in tasks/main.yml) whether it
-# is executed on a container image and sets the variable
-# system_is_container the true. Otherwise, the default value
-# 'false' is left unchanged.
 system_is_container: false
-# The filename of the existing yml file in role's  'vars/' sub-directory
-# to be used for managing the role-behavior when a container was detected:
-# (de)activating rules or for other tasks(e.g. disabling Selinux or a specific
-# firewall-type).
 container_vars_file: is_container.yml
 # rhel9cis is left off the front of this var for consistency in testing pipeline
 # system_is_ec2 toggle will disable tasks that fail on Amazon EC2 instances. Set true to skip and false to run tasks
@@ -23,10 +11,6 @@ system_is_ec2: false
 # Supported OSs will not need for this to be changed - see README e.g. CentOS
 os_check: true
 
-## Switching on/off specific baseline sections
-# These variables govern whether the tasks of a particular section are to be executed when running the role.
-# E.g: If you want to execute the tasks of Section 1 you should set the "_section1" variable to true.
-# If you do not want the tasks from that section to get executed you simply set the variable to "false".
 rhel9cis_section1: true
 rhel9cis_section2: true
 rhel9cis_section3: true
@@ -41,12 +25,7 @@ rhel9cis_section6: true
 rhel9cis_level_1: true
 rhel9cis_level_2: true
 
-## Section 1.6 - Mandatory Access Control
-# This variable governs whether SELinux is disabled or not. If SELinux is NOT DISABLED by setting
-# 'rhel9cis_selinux_disable' to 'true', the 1.6 subsection will be executed.
 rhel9cis_selinux_disable: false
-# This variable is used in a preliminary task, handling grub2 paths either in case of
-# UEFI boot('/etc/grub2-efi.cfg') or in case of BIOS legacy-boot('/etc/grub2.cfg').
 rhel9cis_legacy_boot: false
 
 ## Python Binary
@@ -60,8 +39,7 @@ benchmark_version: 'v1.0.0'
 
 benchmark: RHEL9-CIS
 
-# Whether to skip the system reboot before audit
-# System will reboot if false, can give better audit results
+# Whether to skip the reboot
 skip_reboot: true
 
 # default value will change to true but wont reboot if not enabled but will error
@@ -70,66 +48,44 @@ change_requires_reboot: false
 ##########################################
 ### Goss is required on the remote host ###
 ## Refer to vars/auditd.yml for any other settings ##
-#### Basic external goss audit enablement settings ####
-#### Precise details - per setting can be found at the bottom of this file ####
 
-
-## Audit setup
-# Audits are carried out using Goss. This variable
-# determines whether execution of the role prepares for auditing
-# by installing the required binary.
+# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
 setup_audit: false
 
-## Enable audits to run - this runs the audit and get the latest content
-# This variable governs whether the audit using the
-# separately maintained audit role using Goss
-# is carried out.
+# enable audits to run - this runs the audit and get the latest content
 run_audit: false
 
 # Only run Audit do not remediate
 audit_only: false
-# This will enable files to be copied back to control node(part of audit_only)
+# As part of audit_only
+# This will enable files to be copied back to control node
 fetch_audit_files: false
-# Path to copy the files to will create dir structure(part of audit_only)
+# Path to copy the files to will create dir structure
 audit_capture_files_dir: /some/location to copy to on control node
 
-## How to retrieve audit binary(Goss)
-# Options are 'copy' or 'download' - detailed settings at the bottom of this file
-# - if 'copy':
-#    - the filepath mentioned via the below 'audit_bin_copy_location' var will be used to access already downloaded Goss
-# - if 'download':
-#    - the GitHub Goss-releases URL will be used for a fresh-download, via 'audit_bin_url' and 'audit_pkg_arch_name' vars
+# How to retrieve audit binary
+# Options are copy or download - detailed settings at the bottom of this file
+# you will need to access to either github or the file already dowmloaded
 get_audit_binary_method: download
 
-## if get_audit_binary_method is 'copy', the following var needs to be updated for your environment
+## if get_audit_binary_method - copy the following needs to be updated for your environment
 ## it is expected that it will be copied from somewhere accessible to the control node
 ## e.g copy from ansible control node to remote host
 audit_bin_copy_location: /some/accessible/path
 
-## How to retrieve the audit role
-# The role for auditing is maintained separately.
-# This variable specifies the method of how to get the audit role
+# how to get audit files onto host options
 # options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
-# onto the system. The options are as follows:
-# - 'git': clone audit content from GitHub REPOSITORY, set up via `audit_file_git` var, and
-#          VERSION(e.g. branch, tag name), set up via `audit_git_version` var.
-# - 'copy': copy from path as specified in variable `audit_conf_copy`.
-# - 'archive': same as 'copy', only that the specified filepath needs to be unpacked.
-# - 'get_url': Download from url as specified in variable `audit_files_url`
 audit_content: git
 
-# This variable(only used when 'audit_content' is 'copy' or 'archive') should
-# contain the filepath with audit-content to be copied/unarchived on server:
+# archive or copy:
 audit_conf_copy: "some path to copy from"
 
-# This variable(only used when 'audit_content' is 'get_url') should
-# contain the URL from where the audit-content must be downloaded on server:
+# get_url:
 audit_files_url: "some url maybe s3?"
 
 # Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
 audit_run_heavy_tests: true
 
-# Timeout for those cmds that take longer to run where timeout set
 # This variable specifies the timeout (in ms) for audit commands that
 # take a very long time: if a command takes too long to complete,
 # it will be forcefully terminated after the specified duration.
@@ -141,9 +97,7 @@ audit_cmd_timeout: 120000
 # the CIS benchmark documents.
 # PLEASE NOTE: These work in coordination with the section # group variables and tags.
 # You must enable an entire section in order for the variables below to take effect.
-
-# Section 1 is Initial setup (FileSystem Configuration, Configure Software Updates, Filesystem Integrity Checking, Secure Boot Settings,
-# Additional Process Hardening, Mandatory Access Control, Command Line Warning Banners, and GNOME Display Manager)
+# Section 1 rules
 rhel9cis_rule_1_1_1_1: true
 rhel9cis_rule_1_1_1_2: true
 rhel9cis_rule_1_1_2_1: true
@@ -216,7 +170,7 @@ rhel9cis_rule_1_8_10: true
 rhel9cis_rule_1_9: true
 rhel9cis_rule_1_10: true
 
-# Section 2 rules are controling Services (Special Purpose Services, and service clients)
+# Section 2 rules
 rhel9cis_rule_2_1_1: true
 rhel9cis_rule_2_1_2: true
 rhel9cis_rule_2_2_1: true
@@ -243,7 +197,7 @@ rhel9cis_rule_2_3_3: true
 rhel9cis_rule_2_3_4: true
 rhel9cis_rule_2_4: true
 
-# Section 3 rules are used for securely configuring the network configuration(kernel params, ACL, Firewall settings)
+# Section 3 rules
 rhel9cis_rule_3_1_1: true
 rhel9cis_rule_3_1_2: true
 rhel9cis_rule_3_1_3: true
@@ -268,8 +222,7 @@ rhel9cis_rule_3_4_2_5: true
 rhel9cis_rule_3_4_2_6: true
 rhel9cis_rule_3_4_2_7: true
 
-# Section 4 rules are Logging and Auditing (Configure System Accounting (auditd),
-# Configure Data Retention, and Configure Logging)
+# Section 4 rules
 rhel9cis_rule_4_1_1_1: true
 rhel9cis_rule_4_1_1_2: true
 rhel9cis_rule_4_1_1_3: true
@@ -328,8 +281,7 @@ rhel9cis_rule_4_2_2_7: true
 rhel9cis_rule_4_2_3: true
 rhel9cis_rule_4_3: true
 
-# Section 5 rules control Access, Authentication, and Authorization (Configure time-based job schedulers,
-# Configure sudo, Configure SSH Server, Configure PAM and User Accounts and Environment)
+# Section 5 rules
 rhel9cis_rule_5_1_1: true
 rhel9cis_rule_5_1_2: true
 rhel9cis_rule_5_1_3: true
@@ -384,7 +336,7 @@ rhel9cis_rule_5_6_4: true
 rhel9cis_rule_5_6_5: true
 rhel9cis_rule_5_6_6: true
 
-# Section 6 rules controls System Maintenance (System File Permissions and User and Group Settings)
+# Section 6 rules
 rhel9cis_rule_6_1_1: true
 rhel9cis_rule_6_1_2: true
 rhel9cis_rule_6_1_3: true
@@ -419,371 +371,140 @@ rhel9cis_rule_6_2_16: true
 
 ## Section 1 vars
 
-## Control 1.1.2
-# If set to `true`, rule will be implemented using the `tmp.mount` systemd-service,
-# otherwise fstab configuration will be used.
-# These /tmp settings will include nosuid,nodev,noexec to conform to CIS standards.
+#### 1.1.2
+# These settings go into the /etc/fstab file for the /tmp mount settings
+# The value must contain nosuid,nodev,noexec to conform to CIS standards
+# rhel9cis_tmp_tmpfs_settings: "defaults,rw,nosuid,nodev,noexec,relatime 0 0"
+# If set true uses the tmp.mount service else using fstab configuration
 rhel9cis_tmp_svc: false
 
-## Control 1.1.9
+#### 1.1.9
 rhel9cis_allow_autofs: false
 
-## Control 1.2.1
+# 1.2.1
 # This is the login information for your RedHat Subscription
 # DO NOT USE PLAIN TEXT PASSWORDS!!!!!
 # The intent here is to use a password utility like Ansible Vault here
 rhel9cis_rh_sub_user: user
 rhel9cis_rh_sub_password: password  # pragma: allowlist secret
 
-## Control 1.2.2
+# 1.2.2
 # Do you require rhnsd
 # RedHat Satellite Subscription items
 rhel9cis_rhnsd_required: false
 
-## Control 1.2.4
-# When installing RHEL from authorized Red Hat source, RHEL will come with default YUM repository. NOT having a default YUM
-# repo ('rhel9cis_rhel_default_repo' set as 'false'), in conjunction with 'rhel9cis_rule_enable_repogpg' set as 'True', will enable the tasks
-# which check the GPG signatures for all the individual YUM repositories.
+# 1.2.4 repo_gpgcheck
 rhel9cis_rhel_default_repo: true
-## Control 1.2.4
-# When 'rhel9cis_rule_enable_repogpg' is set to 'true'(in conjunction with 'rhel9cis_rhel_default_repo':'false'), conditions are met for
-# enabling the GPG signatures-check for all the individual YUM repositories. If GPG signatures-check is enabled on repositories which do not
-# support it(like RedHat), installation of packages will fail.
 rhel9cis_rule_enable_repogpg: true
 
-## Control 1.4.1
-# This variable will store the hashed GRUB bootloader password to be stored in '/boot/grub2/user.cfg' file. The default value
-# must be changed to a value that may be generated with this command 'grub2-mkpasswd-pbkdf2' and must comply with
-# this format: 'grub.pbkdf2.sha512.<Rounds>.<Salt>.<Checksum>'
+# 1.4.1 Bootloader password
 rhel9cis_bootloader_password_hash: 'grub.pbkdf2.sha512.10000.9306A36764A7BEA3BF492D1784396B27F52A71812E9955A58709F94EE70697F9BD5366F36E07DEC41B52279A056E2862A93E42069D7BBB08F5DFC2679CD43812.6C32ADA5449303AD5E67A4C150558592A05381331DE6B33463469A236871FA8E70738C6F9066091D877EF88A213C86825E093117F30E9E1BF158D0DB75E7581B'  # pragma: allowlist secret
 rhel9cis_bootloader_password: random  # pragma: allowlist secret
-## Control 1.4.1
-# This variable governs whether a bootloader password should be set in '/boot/grub2/user.cfg' file.
 rhel9cis_set_boot_pass: true
 
-## Control 1.8.x - Settings for GDM
-# This variable specifies the GNOME configuration database file to which configurations are written.
-# (See "https://help.gnome.org/admin/system-admin-guide/stable/dconf-keyfiles.html.en")
-# The default database is 'local'.
+# 1.8 Gnome Desktop
 rhel9cis_dconf_db_name: local
-# This variable governs the number of seconds of inactivity before the screen goes blank.
-# Set max value for idle-delay in seconds (between 1 and 900)
-rhel9cis_screensaver_idle_delay: 900
-# This variable governs the number of seconds the screen remains blank before it is locked.
-# Set max value for lock-delay in seconds (between 0 and 5)
-rhel9cis_screensaver_lock_delay: 5
+rhel9cis_screensaver_idle_delay: 900  # Set max value for idle-delay in seconds (between 1 and 900)
+rhel9cis_screensaver_lock_delay: 5  # Set max value for lock-delay in seconds (between 0 and 5)
 
-## Control 1.10
-# This variable contains the value to be set as the system-wide crypto policy. Current rule enforces NOT USING
-# 'LEGACY' value(as it is less secure, it just ensures compatibility with legacy systems), therefore
-# possible values for this variable are, as explained by RedHat docs:
-#  -'DEFAULT': reasonable default policy for today's standards (balances usability and security)
-#  -'FUTURE': conservative security level that is believed to withstand any near-term future attacks
-#  -'FIPS': A level that conforms to the FIPS140-2 requirements
+# 1.10/1.11 Set crypto policy (LEGACY, DEFAULT, FUTURE, FIPS)
+# Control 1.10 states do not use LEGACY and control 1.11 says to use FUTURE or FIPS.
 rhel9cis_crypto_policy: 'DEFAULT'
-## Control 1.10
-# This variable contains the value of the crypto policy module(combinations of policies and
-# sub-policies) to be allowed as default setting. Allowed options are defined in 'vars/main.yml' file,
-# using 'rhel9cis_allowed_crypto_policies_modules' variable.
+# Added module to be allowed as default setting (Allowed options in vars/main.yml)
 rhel9cis_crypto_policy_module: ''
 
 # System network parameters (host only OR host and router)
-# This variable governs whether specific CIS rules
-# concerned with acceptance and routing of packages are skipped.
 rhel9cis_is_router: false
 
-## IPv6 requirement toggle
-# This variable governs whether ipv6 is enabled or disabled.
+# IPv6 required
 rhel9cis_ipv6_required: true
 
-## Control 1.3.1 - allow aide to be configured
-# AIDE is a file integrity checking tool, similar in nature to Tripwire.
-# While it cannot prevent intrusions, it can detect unauthorized changes
-# to configuration files by alerting when the files are changed. Review
-# the AIDE quick start guide and AIDE documentation before proceeding.
-# By setting this variable to `true`, all of the settings related to AIDE will be applied!
+# AIDE
 rhel9cis_config_aide: true
-
-## Control 1.3.2 AIDE cron settings
-# These are the crontab settings for periodical checking of the filesystem's integrity using AIDE.
-# The sub-settings of this variable provide the parameters required to configure
-# the cron job on the target system.
-# Cron is a time-based job scheduling program in Unix OS, which allows tasks to be scheduled
-# and executed automatically at a certain point in time.
+# AIDE cron settings
 rhel9cis_aide_cron:
-    # This variable represents the user account under which the cron job for AIDE will run.
     cron_user: root
-    # This variable represents the path to the AIDE crontab file.
     cron_file: /etc/cron.d/aide_cron
-    # This variable represents the actual command or script that the cron job
-    # will execute for running AIDE.
     aide_job: '/usr/sbin/aide --check'
-    # These variables define the schedule for the cron job
-    # This variable governs the minute of the time of day when the AIDE cronjob is run.
-    # It must be in the range `0-59`.
     aide_minute: 0
-    # This variable governs the hour of the time of day when the AIDE cronjob is run.
-    # It must be in the range `0-23`.
     aide_hour: 5
-    # This variable governs the day of the month when the AIDE cronjob is run.
-    # `*` signifies that the job is run on all days; furthermore, specific days
-    # can be given in the range `1-31`; several days can be concatenated with a comma.
-    # The specified day(s) can must be in the range  `1-31`.
     aide_day: '*'
-    # This variable governs months when the AIDE cronjob is run.
-    # `*` signifies that the job is run in every month; furthermore, specific months
-    # can be given in the range `1-12`; several months can be concatenated with commas.
-    # The specified month(s) can must be in the range  `1-12`.
     aide_month: '*'
-    # This variable governs the weekdays, when the AIDE cronjob is run.
-    # `*` signifies that the job is run on all weekdays; furthermore, specific weekdays
-    # can be given in the range `0-7` (both `0` and `7` represent Sunday); several weekdays
-    # can be concatenated with commas.
     aide_weekday: '*'
 
-## Control 1.6.1.3|4|5 - SELinux policy settings
-# This selects type of policy; targeted or mls( multilevel )
-# mls should not be used, since it will disable unconfined policy module
-# and may prevent some services from running. Requires SELinux not being disabled (by
-# having 'rhel9cis_selinux_disable' var set as 'true'), otherwise setting will be ignored.
+# SELinux policy
 rhel9cis_selinux_pol: targeted
-## Control 1.6.1.3|4 - SELinux configured and not disabled
-# This variable contains a specific SELinux mode, respectively:
-#  - 'enforcing':  SELinux policy IS enforced, therefore denies operations based on SELinux policy
-# rules. If system was installed with SELinux, this is enabled by default.
-#  - 'permissive': SELinux policy IS NOT enforced, therefore does NOT deny any operation, only
-# logs AVC(Access Vector Cache) messages. RedHat docs suggest it "can be used
-# briefly to check if SELinux is the culprit in preventing your application
-# from working".
-# CIS expects enforcing since permissive allows operations that might compromise the system.
-# Even though logging still occurs.
+# chose onf or enfocing or permissive
 rhel9cis_selinux_enforce: enforcing
 
 # Whether or not to run tasks related to auditing/patching the desktop environment
 
-## Section 2. Services
+## 2. Services
 
 ### 2.1 Time Synchronization
-
-
-## Control 2.1.2 Time Synchronization servers - used in template file chrony.conf.j2
-# The following variable represents a list of time servers used
-# for configuring chrony, timesyncd, and ntp.
-# Each list item contains two settings, `name` (the domain name of the server) and synchronization `options`.
-# The default setting for the `options` is `minpoll` but `iburst` can be used, please refer to the documentation
-# of the time synchronization mechanism you are using.
+#### 2.1.2 Time Synchronization servers - used in template file chrony.conf.j2
 rhel9cis_time_synchronization_servers:
     - 0.pool.ntp.org
     - 1.pool.ntp.org
     - 2.pool.ntp.org
     - 3.pool.ntp.org
-## Control 2.1.2 - Time Synchronization servers
-# This variable should contain the default options to be used for every NTP server hostname defined
-# within the 'rhel9cis_time_synchronization_servers' var.
 rhel9cis_chrony_server_options: "minpoll 8"
-# This variable, if set to 'true'(default), will inform the kernel the system clock is kept synchronized
-# and the kernel will update the real-time clock every 11 minutes. Otherwise, if 'rtcsync' option is
-# disabled, chronyd will not be in sync(kernel discipline is disabled, 11 minutes mode will be off).
 rhel9cis_chrony_server_rtcsync: false
-# This variable configures the values to be used by chronyd to gradually correct any time offset,
-# by slowing down/speeding up the clock. An example of this directive usage would be:
-# 'makestep 1000 10'.
-# Step the system clock:
-#   - IF the adjustment is larger than 1000 seconds
-#   - but ONLY IN the first ten clock updates
 rhel9cis_chrony_server_makestep: "1.0 3"
-# This variable configures the minimum number of sources that need to be considered as selectable in the source
-# selection algorithm before the local clock is updated. Setting minsources to a larger number can be used to
-# improve the reliability, because multiple sources will need to correspond with each other.
 rhel9cis_chrony_server_minsources: 2
 
-
 ### 2.2 Special Purposes
-
-# Service configuration variables (boolean).
-# Set the respective variable to true to keep the service.
-# otherwise the service is stopped and disabled
-
-
-# This variable governs whether rules dealing with GUI specific packages(and/or their settings) should
-# be executed either to:
-# - secure GDM, if GUI is needed('rhel9cis_gui: true')
-# - or remove GDM and X-Windows-system, if no GUI is needed('rhel9cis_gui: false')
+##### Service configuration booleans set true to keep service
 rhel9cis_gui: false
-## Control 2.2.2 - Ensure Avahi Server is not installed
-# This variable, when set to false, will specify that Avahi Server packages should be uninstalled.
 rhel9cis_avahi_server: false
-## Control 2.2.3 -  Ensure CUPS is not installed
-# This variable, when set to false, will specify that CUPS(Common UNIX Printing System) package should be uninstalled.
 rhel9cis_cups_server: false
-## Control 2.2.4 - Ensure DHCP Server is not installed
-# This variable, when set to false, will specify that DHCP server package should be uninstalled.
 rhel9cis_dhcp_server: false
-## Control 2.2.5 - Ensure DNS Server is not installed
-# This variable, when set to false, will specify that DNS server package should be uninstalled.
 rhel9cis_dns_server: false
-## Control 2.2.14 - Ensure dnsmasq is not installed
-# This variable, when set to false, will specify that dnsmasq package should be uninstalled.
 rhel9cis_dnsmasq_server: false
-## Control 2.2.6 - Ensure VSFTP Server is not installed
-# This variable, when set to false, will specify that VSFTP server package should be uninstalled.
 rhel9cis_vsftpd_server: false
-## Control 2.2.7 - Ensure TFTP Server is not installed
-# This variable, when set to false, will specify that TFTP server package should be uninstalled.
 rhel9cis_tftp_server: false
-## Control 2.2.8 - Ensure a web server is not installed - HTTPD
-# This variable, when set to false, will specify that webserver packages(HTTPD) should be uninstalled.
 rhel9cis_httpd_server: false
-## Control 2.2.8 - Ensure a web server is not installed - NGINX
-# This variable, when set to false, will specify that webserver packages(NGINX) should be uninstalled.
 rhel9cis_nginx_server: false
-## Control 2.2.9 - Ensure IMAP and POP3 server is not installed - dovecot
-# This variable, when set to false, will specify that IMAP and POP3 servers(dovecot) should be uninstalled.
 rhel9cis_dovecot_server: false
-## Control 2.2.9 - Ensure IMAP and POP3 server is not installed - cyrus-imapd
-# This variable, when set to false, will specify that IMAP and POP3 servers(cyrus-imapd) should be uninstalled.
 rhel9cis_imap_server: false
-## Control 2.2.10 - Ensure Samba is not enabled
-# This variable, when set to false, will specify that 'samba' package should be uninstalled.
 rhel9cis_samba_server: false
-## Control 2.2.11 - Ensure HTTP Proxy Server is not installed
-# This variable, when set to false, will specify that 'squid' package should be uninstalled.
 rhel9cis_squid_server: false
-## Control 2.2.12 - Ensure net-snmp is not installed
-# This variable, when set to false, will specify that 'net-snmp' package should be uninstalled.
 rhel9cis_snmp_server: false
-## Control 2.2.13 - Ensure telnet-server is not installed
-# This variable, when set to false, will specify that 'telnet-server' package should be uninstalled.
 rhel9cis_telnet_server: false
-## Control 2.2.15 - Ensure mail transfer agent is configured for local-only mode
-# This variable, when system is NOT a mailserver, will configure Postfix to listen only on the loopback interface(the virtual
-# network interface that the server uses to communicate internally.
 rhel9cis_is_mail_server: false
 # Note the options
-# Client package configuration variables.
 # Packages are used for client services and Server- only remove if you dont use the client service
-# Set the respective variable to `true` to keep the
-# client package, otherwise it is uninstalled (false).
+#
 
-## Control 2.2.16 - Ensure nfs-utils is not installed or the nfs-server service is masked"
-# This variable specifies if the usage of NFS SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
-# NFS(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_nfs_service') with current one, respectively:
-# - if Server IS NOT needed('false') and:
-#    - Service IS NOT needed('rhel9cis_use_nfs_service: false'): 'nfs-utils' package will be removed
-#    - Service IS needed('rhel9cis_use_nfs_service: true'): impossible to need the service without the server
-# - if Server IS needed('true') and:
-#    - Service IS NOT needed('rhel9cis_use_nfs_service: false'): 'nfs-server' service will be masked
-#    - Service IS needed('rhel9cis_use_nfs_service: true'): Rule will be SKIPPED.
-#  | Server  | Service | Result                                                    |
-#  |---------|---------|-----------------------------------------------------------|
-#  | false   | false   | Remove package                                            |
-#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
-#  | true    | false   | Mask 'service'                                            |
-#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_nfs_server: false
-## Control 2.2.16 - Ensure nfs-utils is not installed or the nfs-server service is masked.
-# This variable specifies if the usage of NFS SERVICE is needed. If it's:
-#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
-#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being
-#    controlled by the var used in conjunction with current one:
-#          - removing 'nfs-utils' package('rhel9cis_use_nfs_server' set to 'false')
-#          - masking the 'nfs-server' service('rhel9cis_use_nfs_server' set to 'true')
 rhel9cis_use_nfs_service: false
 
-## Control 2.2.17 - Ensure rpcbind is not installed or the rpcbind services are masked
-# This variable specifies if the usage of RPC SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
-# RPC(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_rpc_service') with current one, respectively:
-# - if Server IS NOT needed('false') and:
-#    - Service IS NOT needed('rhel9cis_use_rpc_service: false'): 'rpcbind' package will be removed
-#    - Service IS needed('rhel9cis_use_rpc_service: true'): impossible to need the service without the server
-# - if Server IS needed('true') and:
-#    - Service IS NOT needed('rhel9cis_use_rpc_service: false'): 'rpcbind.socket' service will be masked
-#    - Service IS needed('rhel9cis_use_rpc_service: true'): Rule will be SKIPPED.
-#  | Server  | Service | Result                                                    |
-#  |---------|---------|-----------------------------------------------------------|
-#  | false   | false   | Remove package                                            |
-#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
-#  | true    | false   | Mask 'service'                                            |
-#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_rpc_server: false
-## Control 2.2.17 - Ensure rpcbind is not installed or the rpcbind services are masked
-# This variable specifies if the usage of RPC SERVICE is needed. If it's:
-#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
-#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being controlled by the var
-#     used in conjunction with current one:
-#          - removing 'rpcbind' package('rhel9cis_use_rpc_server' set to 'false')
-#          - masking the 'rpcbind.socket' service('rhel9cis_use_rpc_server' set to 'true')
 rhel9cis_use_rpc_service: false
 
-## Control 2.2.18 - Ensure rsync service is not enabled
-# This variable specifies if the usage of RSYNC SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
-# RSYNC(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_rsync_service') with current one, respectively:
-# - if Server IS NOT needed('false') and:
-#    - Service IS NOT needed('rhel9cis_use_rsync_service: false'): 'rsync-daemon' package will be removed
-#    - Service IS needed('rhel9cis_use_rsync_service: true'): impossible to need the service without the server
-# - if Server IS needed('true') and:
-#    - Service IS NOT needed('rhel9cis_use_rsync_service: false'): 'rsyncd' service will be masked
-#    - Service IS needed('rhel9cis_use_rsync_service: true'): Rule will be SKIPPED.
-#  | Server  | Service | Result                                                    |
-#  |---------|---------|-----------------------------------------------------------|
-#  | false   | false   | Remove package                                            |
-#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
-#  | true    | false   | Mask 'service'                                            |
-#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_rsync_server: false
-## Control 2.2.18 - Ensure rsync service is not enabled
-# This variable specifies if the usage of RSYNC SERVICE is needed. If it's:
-#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
-#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being controlled by the var
-#     used in conjunction with current one:
-#          - removing 'rsync-daemon' package('rhel9cis_use_rsync_server' set to 'false')
-#          - masking the 'rsyncd' service('rhel9cis_use_rsync_server' set to 'true')
 rhel9cis_use_rsync_service: false
 
 #### 2.3 Service clients
-
-
-## Control - 2.3.1 - Ensure telnet client is not installed
-# Set this variable to `true` to keep package `telnet`; otherwise, the package is uninstalled.
 rhel9cis_telnet_required: false
-## Control - 2.3.2 - Ensure LDAP client is not installed
-# Set this variable to `true` to keep package `openldap-clients`; otherwise, the package is uninstalled.
 rhel9cis_openldap_clients_required: false
-## Control - 2.3.3 - Ensure FTP client is not installed
-# Set this variable to `true` to keep package `tftp`; otherwise, the package is uninstalled.
 rhel9cis_tftp_client: false
-## Control - 2.3.4 - Ensure FTP client is not installed
-# Set this variable to `true` to keep package `ftp`; otherwise, the package is uninstalled.
 rhel9cis_ftp_client: false
 
-## Section 3 vars for
+## Section3 vars
 ## Sysctl
-
-
-# This variable governs if the task which updates sysctl(including sysctl reload) is executed.
-# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_sysctl_update: false
-# This variable governs if the task which flushes the IPv4 routing table is executed(forcing subsequent connections to
-# use the new configuration).
-# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_flush_ipv4_route: false
-# This variable governs if the task which flushes the IPv6 routing table is executed(forcing subsequent connections to
-# use the new configuration).
-# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_flush_ipv6_route: false
 
-### Firewall Service to install and configure - Options are:
-# 1) either 'firewalld'
-# 2) or 'nftables'
+### Firewall Service - either firewalld, iptables, or nftables
 #### Some control allow for services to be removed or masked
 #### The options are under each heading
 #### absent = remove the package
 #### masked = leave package if installed and mask the service
 rhel9cis_firewall: firewalld
 
-## Control 3.4.2.1 - Ensure firewalld default zone is set
-# This variable will set the firewalld default zone(that is used for everything that is not explicitly bound/assigned
-# to another zone): if there is no zone assigned to a connection, interface or source, only the default zone is used.
+##### firewalld
 rhel9cis_default_zone: public
 
 # These settings are added to demonstrate how this update can be done (eventually will require a new control)
@@ -791,66 +512,24 @@ rhel9cis_firewalld_ports:
     - number: 80
       protocol: tcp
 
-## Controls 3.5.2.x - nftables
-
-
-## Control 3.4.2.2 - Ensure at least one nftables table exists
-# This variable governs if a table will be automatically created in nftables. Without a table (no default one), nftables
-# will not filter network traffic, so if this variable is set to 'false' and no tables exist, an alarm will be triggered!
+#### nftables
 rhel9cis_nft_tables_autonewtable: true
-## Controls 3.4.2.{2|3|4|6|7} nftables
-# This variable stores the name of the table to be used when configuring nftables(creating chains, configuring loopback
-# traffic, established connections, default deny). If 'rhel9cis_nft_tables_autonewtable' is set as true, a new table will
-# be created using as name the value stored by this variable.
 rhel9cis_nft_tables_tablename: filter
-## Control 3.4.2.3 - Ensure nftables base chains exist
-# This variable governs if a nftables base chain(entry point for packets from the networking stack) will be automatically
-# created, if needed. Without a chain, a hook for input, forward, and delete, packets that would flow through those
-# chains will not be touched by nftables.
 rhel9cis_nft_tables_autochaincreate: true
 
-## Controls:
-# - 1.7.1 - Ensure message of the day is configured properly
-# - 1.7.2 - Ensure local login warning banner is configured properly
-# - 1.7.3 - Ensure remote login warning banner is configured properly
-# This variable  stores the content for the Warning Banner(relevant for issue, issue.net, motd).
+# Warning Banner Content (issue, issue.net, motd)
 rhel9cis_warning_banner: Authorized uses only. All activity may be monitored and reported.
 # End Banner
 
 ## Section4 vars
 ### 4.1 Configure System Accounting
 #### 4.1.2 Configure Data Retention
-## Controls what actions, when log files fill up
-# This variable controls how the audit system behaves when
-# log files are getting too full and space is getting too low.
 rhel9cis_auditd:
-    # This variable tells the system what action to take when the system has detected
-    # that it is starting to get low on disk space. Options are the same as for `admin_space_left_action`.
     space_left_action: email
-    # This variable should contain a valid email address or alias(default value is root),
-    # which will be used to send a warning when configured action is 'email'.
     action_mail_acct: root
-    # This variable determines the action the audit system should take when disk
-    # space runs low.
-    # The options for setting this variable are as follows:
-    # - `ignore`: the system does nothing when presented with the aforementioned issue;
-    # - `syslog`: a message is sent to the system log about disk space running low;
-    # - `suspend`: the system suspends recording audit events until more space is available;
-    # - `halt`: the system is halted when disk space is critically low.
-    # - `single`: the audit daemon will put the computer system in single user mode
-    # CIS prescribes either `halt` or `single`.
     admin_space_left_action: halt
     # The max_log_file parameter should be based on your sites policy.
     max_log_file: 10
-    # This variable determines what action the audit system should take when the maximum
-    # size of a log file is reached.
-    # The options for setting this variable are as follows:
-    # - `ignore`: the system does nothing when the size of a log file is full;
-    # - `syslog`: a message is sent to the system log indicating the problem;
-    # - `suspend`: the system suspends recording audit events until the log file is cleared or rotated;
-    # - `rotate`: the log file is rotated (archived) and a new empty log file is created;
-    # - `keep_logs`: the system attempts to keep as many logs as possible without violating disk space constraints.
-    # CIS prescribes the value `keep_logs`.
     max_log_file_action: keep_logs
 
 ##  Control 4.1.1.4 - Ensure rhel9cis_audit_back_log_limit is sufficient
@@ -871,390 +550,150 @@ rhel9cis_auditd_extra_conf:
     space_left: 75
 
 # The audit_back_log_limit value should never be below 8192
-##  Control 4.1.1.4 - Ensure rhel9cis_audit_back_log_limit is sufficient
-# This variable represents the audit backlog limit, i.e., the maximum number of audit records that the
-# system can buffer in memory, if the audit subsystem is unable to process them in real-time.
-# Buffering in memory is useful in situations, where the audit system is overwhelmed
-# with incoming audit events, and needs to temporarily store them until they can be processed.
-# This variable should be set to a sufficient value. The CIS baseline recommends at least `8192` as value.
 rhel9cis_audit_back_log_limit: 8192
 
 ### 4.1.3.x audit template
-## Control 4.1.2.1 - Ensure audit log storage size is configured
-# This variable specifies the maximum size in MB that an audit log file can reach
-# before it is archived or deleted to make space for the new audit data.
-# This should be set based on your sites policy. CIS does not provide a specific value.
-rhel9cis_max_log_file_size: 10
-
-## Control 4.1.3.x - Audit template
-# This variable governs if the auditd logic should be executed(if value is true).
-# NOTE: The current default value is likely to be overriden(via 'set_fact') by other further tasks(in sub-section 'Auditd rules').
 update_audit_template: false
 
 ## Advanced option found in auditd post
-# This variable governs if defining user exceptions for auditd logging is acceptable.
 rhel9cis_allow_auditd_uid_user_exclusions: false
-# This variable contains a list of uids to be excluded(users whose actions are not logged by auditd)
-rhel9cis_auditd_uid_exclude:
-    - 1999
 
 ## Preferred method of logging
-## Control 'Configure other keys for auditd.conf' in 4.1.2.x section
-# The default auditd configuration should be suitable for most environments, but if your environment must
-# meet strict security policies, the extra configuration pairs used for securing auditd(by modifying
-# '/etc/audit/auditd.conf' file) can be stored within current variable.
 ## Whether rsyslog or journald preferred method for local logging
-## Control 4.2.1 | Configure rsyslog
-## Control 4.2.2 | Configure journald
-# This variable governs which logging service should be used, choosing between 'rsyslog'(CIS recommendation)
-# or 'journald'(only one is implemented) will trigger the execution of the associated subsection, as the-best
-# practices are written wholly independent of each other.
+## Affects rsyslog cis 4.2.1.3 and journald cis 4.2.2.5
 rhel9cis_syslog: rsyslog
-## Control 4.2.1.5 | PATCH | Ensure logging is configured
-# This variable governs if current Ansible role should manage syslog settings
-# in /etc/rsyslog.conf file, namely mail, news and misc(warn, messages)
 rhel9cis_rsyslog_ansiblemanaged: true
 
-## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
-# This variable governs if 'rsyslog' service should be automatically configured to forward messages to a
-# remote log server. If set to 'false', the configuration of the 'omfwd' plugin, used to provide forwarding
-# over UDP or TCP, will not be performed.
+#### 4.2.1.6 remote and destation log server name
 rhel9cis_remote_log_server: false
-## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
-# This variable configures the value of the 'target' parameter to be configured when enabling
-# forwarding syslog messages to a remote log server, thus configuring the actual FQDN/IP address of the
-# destination server. For this value to be reflected in the configuration, the variable which enables the
-# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_host: logagg.example.com
-## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
-# This variable configures the value of the 'port' parameter to be configured when enabling
-# forwarding syslog messages to a remote log server. The default value for this destination port is 514.
-# For this value to be reflected in the configuration, the variable which enables the
-# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_port: 514
-## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
-# This variable configures the value("TCP"/"UDP") of the 'protocol' parameter to be configured when enabling
-# forwarding syslog messages to a remote log server. The default value for the 'omfwd' plug-in is UDP.
-# For this value to be reflected in the configuration, the variable which enables the
-# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_protocol: tcp
-## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
-# This variable governs how often an action is retried(value is passed to 'action.resumeRetryCount' parameter) before
-# it is considered to have failed(that roughly translates to discarded messages). The default value is 0, but
-# when set to "-1"(eternal), this setting would prevent rsyslog from dropping messages when retrying to connect
-# if server is not responding. For this value to be reflected in the configuration, the variable which enables the
-# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_retrycount: 100
-## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
-# This variable configures the maximum number of messages that can be hold(value is passed to 'queue.size' parameter).
-# For this value to be reflected in the configuration, the variable which enables the automatic configuration
-# of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_queuesize: 1000
 
-## Control 4.2.1.7 - Ensure rsyslog is not configured to receive logs from a remote client
-# This variable expresses whether the system is used as a log server or not. If set to:
-#  - 'false', current system will act as a log CLIENT, thus it should NOT receive data from other hosts.
-#  - 'true', current system will act as a log SERVER, enabling centralised log management(by protecting log integrity
-# from local attacks on remote clients)
+#### 4.2.1.7
 rhel9cis_system_is_log_server: false
 
-## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
-# 'rhel9cis_journal_upload_url' is the ip address to upload the journal entries to
-#  URL value may specify either just the hostname or both the protocol and hostname. 'https' is the default. The port
-#  number may be specified after a colon (":"), otherwise 19532 will be used by default.
+# 4.2.2.1.2
+# rhel9cis_journal_upload_url is the ip address to upload the journal entries to
 rhel9cis_journal_upload_url: 192.168.50.42
-## The paths below have the default paths/files, but allow user to create custom paths/filenames
-## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
-# This variable specifies the path to the private key file used by the remote journal
-# server to authenticate itself to the client. This key is used alongside the server's
-# public certificate to establish secure communication.
+# The paths below have the default paths/files, but allow user to create custom paths/filenames
 rhel9cis_journal_upload_serverkeyfile: "/etc/ssl/private/journal-upload.pem"
-## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
-# This variable specifies the path to the public certificate file of the remote journal
-# server. This certificate is used to verify the authenticity of the remote server.
 rhel9cis_journal_servercertificatefile: "/etc/ssl/certs/journal-upload.pem"
-## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
-# This variable specifies the path to a file containing one or more public certificates
-# of certificate authorities (CAs) that the client trusts. These trusted certificates are used
-# to validate the authenticity of the remote server's certificate.
 rhel9cis_journal_trustedcertificatefile: "/etc/ssl/ca/trusted.pem"
-# ATTENTION: Uncomment the keyword below when values are set!
 
-## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
-# Current variable configures the max amount of disk space the logs will use(thus, journal files
-# will not grow without bounds)
+# 4.2.2.1
 # The variables below related to journald, please set these to your site specific values
-# These variable specifies how much disk space the journal may use up at most
-# Specify values in bytes or use K, M, G, T, P, E as units for the specified sizes.
-# See https://www.freedesktop.org/software/systemd/man/journald.conf.html for more information.
+# rhel9cis_journald_systemmaxuse is the max amount of disk space the logs will use
 rhel9cis_journald_systemmaxuse: 10M
-## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
-# Current variable configures the amount of disk space to keep free for other uses.
+# rhel9cis_journald_systemkeepfree is the amount of disk space to keep free
 rhel9cis_journald_systemkeepfree: 100G
-## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
-# This variable configures how much disk space the journal may use up at most.
-# Similar with 'rhel9cis_journald_systemmaxuse', but related to runtime space.
 rhel9cis_journald_runtimemaxuse: 10M
-## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
-# This variable configures the actual amount of disk space to keep free
-# Similar with 'rhel9cis_journald_systemkeepfree', but related to runtime space.
 rhel9cis_journald_runtimekeepfree: 100G
-## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
-# Current variable governs the settings for log retention(how long the log files will be kept).
-# Thus, it specifies the maximum time to store entries in a single journal
-# file before rotating to the next one. Set to 0 to turn off this feature.
-# The given values is interpreted as seconds, unless suffixed with the units
-# `year`, `month`, `week`, `day`, `h` or `m` to override the default time unit of seconds.
-# Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
-# ATTENTION: Uncomment the keyword below when values are set!
+# rhel9cis_journald_MaxFileSec is how long in time to keep log files. Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
 rhel9cis_journald_maxfilesec: 1month
 
-## Control 4.3 - Ensure logrotate is configured
-# This variable defines the log file rotation period.
-# Options are: daily, weekly, monthly, yearly.
+#### 4.3
 rhel9cis_logrotate: "daily"
 
 ## Section5 vars
 
-## Section 5.2 - SSH
-
-# This value, containing the absolute filepath of the produced 'sshd' config file, allows usage of
-# drop-in files('/etc/ssh/ssh_config.d/{ssh_drop_in_name}.conf', supported by RHEL9) when CIS adopts them.
-# Otherwise, the default value is '/etc/ssh/ssh_config'.
+# This will allow use of drop in files when CIS adopts them.
 rhel9_cis_sshd_config_file: /etc/ssh/sshd_config
 
-## Controls:
-## - 5.2.4  - Ensure SSH access is limited
-## - 5.2.19 - Ensure SSH LoginGraceTime is set to one minute or less
-## - 5.2.20 - Ensure SSH Idle Timeout Interval is configured
 rhel9cis_sshd:
-    # This variable sets the maximum number of unresponsive "keep-alive" messages
-    # that can be sent from the server to the client before the connection is considered
-    # inactive and thus, closed.
     clientalivecountmax: 0
-    # This variable sets the time interval in seconds between sending "keep-alive"
-    # messages from the server to the client. These types of messages are intended to
-    # keep the connection alive and prevent it being terminated due to inactivity.
     clientaliveinterval: 900
-    # This variable specifies the amount of seconds allowed for successful authentication to
-    # the SSH server.
     logingracetime: 60
     # WARNING: make sure you understand the precedence when working with these values!!
     # allowusers:
     # allowgroups: systems dba
     # denyusers:
     # denygroups:
-    # This variable, if specified, configures a list of USER name patterns, separated by spaces, to allow SSH
-    # access for users whose user name matches one of the patterns. This is done
-    # by setting the value of `AllowUsers` option in `/etc/ssh/sshd_config` file.
-    # If an USER@HOST format will be used, the specified user will be allowed only on that particular host.
-    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
-    # For more info, see https://linux.die.net/man/5/sshd_config
-    allow_users: ""
-    # (String) This variable, if spcieifed, configures a list of GROUP name patterns, separated by spaces, to allow SSH access
-    # for users whose primary group or supplementary group list matches one of the patterns. This is done
-    # by setting the value of `AllowGroups` option in `/etc/ssh/sshd_config` file.
-    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
-    # For more info, https://linux.die.net/man/5/sshd_config
-    allow_groups: "wheel"
-    # This variable, if specified, configures a list of USER name patterns, separated by spaces, to prevent SSH access
-    # for users whose user name matches one of the patterns. This is done
-    # by setting the value of `DenyUsers` option in `/etc/ssh/sshd_config` file.
-    # If an USER@HOST format will be used, the specified user will be restricted only on that particular host.
-    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
-    # For more info, see https://linux.die.net/man/5/sshd_config
-    deny_users: "nobody"
-    # This variable, if specified, configures a list of GROUP name patterns, separated by spaces, to prevent SSH access
-    # for users whose primary group or supplementary group list matches one of the patterns. This is done
-    # by setting the value of `DenyGroups` option in `/etc/ssh/sshd_config` file.
-    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
-    # For more info, see https://linux.die.net/man/5/sshd_config
-    deny_groups: ""
 
-## Control 5.2.5 - Ensure SSH LogLevel is appropriate
-# This variable is used to control the verbosity of the logging produced by the SSH server.
-# The options for setting it are as follows:
-# - `QUIET`: Minimal logging;
-# - `FATAL`: logs only fatal errors;
-# - `ERROR`: logs error messages;
-# - `INFO`: logs informational messages in addition to errors;
-# - `VERBOSE`: logs a higher level of detail, including login attempts and key exchanges;
-# - `DEBUG`: generates very detailed debugging information including sensitive information.
-# - `DEBUG(x)`: Whereas x = debug level 1 to 3, DEBUG=DEBUG1.
+# 5.2.5 SSH LogLevel setting. Options are INFO or VERBOSE
 rhel9cis_ssh_loglevel: INFO
 
-## Control 5.2.18 - Ensure SSH MaxSessions is set to 10 or less
-# This variable value specifies the maximum number of open sessions that are permitted from
-# a given location
+# 5.2.19 SSH MaxSessions setting. Must be 4 our less
 rhel9cis_ssh_maxsessions: 4
-
-## Control 5.6.1.4 - Ensure inactive password lock is 30 days or less
 rhel9cis_inactivelock:
-# This variable specifies the number of days of inactivity before an account will be locked.
-# CIS requires a value of 30 days or less.
     lock_days: 30
-# This variable governs if authconfig package should be installed. This package provides a simple method of
-# configuring /etc/sysconfig/network to handle NIS, as well as /etc/passwd and /etc/shadow, the files used
-# for shadow password support. Basic LDAP, Kerberos 5, and Winbind client configuration is also provided.
-rhel9cis_use_authconfig: false
 
-## Section 5.4 - Configure authselect: Custom authselect profile settings(name, profile to customize, options)
-## Controls:
-#  - 5.4.1 - Ensure custom authselect profile is used('custom_profile_name', 'default_file_to_copy' subsettings)
-#  - 5.4.2 - Ensure authselect includes with-faillock | with auth select profile('custom_profile_name')
-# Settings in place now will fail, they are placeholders from the control example. Due to the way many multiple
-# options and ways to configure this control needs to be enabled and settings adjusted to minimise risk.
+rhel9cis_use_authconfig: false
+# 5.3.1/5.3.2 Custom authselect profile settings. Settings in place now will fail, they are place holders from the control example
+# Due to the way many multiple options and ways to configure this control needs to be enabled and settings adjusted to minimise risk
 rhel9cis_authselect:
-    # This variable configures the name of the custom profile to be created and selected.
     custom_profile_name: custom-profile
-    # This variable configures the ID of the existing profile that should be used as a base for the new profile.
     default_file_to_copy: "sssd --symlink-meta"
     options: with-sudo with-faillock without-nullok
 
-## Control 5.4.1 - Ensure custom authselect profile is used
-# This variable governs if an authselect custom profile should be automatically created, by copying and
-# customizing one of the default profiles. The default profiles include: sssd, winbind, or the nis. This profile can then be
-# customized to follow site specific requirements.
+# 5.3.1 Enable automation to create custom profile settings, using the settings above
 rhel9cis_authselect_custom_profile_create: false
 
-## Control 5.4.2 - Ensure authselect includes with-faillock | Create custom profiles
-# This variable governs if the existing custom profile should be selected(Note: please keep in mind that all future updates
-# to the PAM templates and meta files in the original profile will be reflected in your custom profile, too.)
+# 5.3.2 Enable automation to select custom profile options, using the settings above
 rhel9cis_authselect_custom_profile_select: false
 
-## Section 5.6.1.x: Shadow Password Suite Parameters
 rhel9cis_pass:
-    ## Control 5.6.1.1 - Ensure password expiration is 365 days or less
-    # This variable governs after how many days a password expires.
-    # CIS requires a value of 365 or less.
     max_days: 365
-    ## Control 5.6.1.2 - Ensure minimum days between password changes is 7 or more
-    # This variable specifies the minimum number of days allowed between changing
-    # passwords. CIS requires a value of at least 1.
     min_days: 7
-    ## Control 5.6.1.3 - Ensure password expiration warning days is 7 or more
-    # This variable governs, how many days before a password expires, the user will be warned.
-    # CIS requires a value of at least 7.
     warn_age: 7
 
-## Control 5.5.1 - Ensure password creation requirements are configured  - PAM
+# 5.5.1
+## PAM
 rhel9cis_pam_password:
-    # This variable sets the minimum chars a password needs to be set.
     minlen: 14
-    # This variable set password complexity,the minimum number of
-    # character types that must be used (i.e., uppercase, lowercase, digits, other)
-    # Set to 2, passwords cannot have all lower/upper case.
-    # Set to 3, passwords needs numbers.
-    # set to 4, passwords will have to include all four types of characters.
     minclass: 4
 
-## Controls
-# - 5.5.2 - Ensure lockout for failed password attempts is configured
-# - 5.5.3 - Ensure password reuse is limited
-# - 5.5.4 - Ensure password hashing algorithm is SHA-512
-# - 5.4.2 -  Ensure authselect includes with-faillock
 rhel9cis_pam_faillock:
-    # This variable sets the amount of time a user will be unlocked after the max amount of
-    #   password failures.
     unlock_time: 900
-    # This variable sets the amount of tries a password can be entered, before a user is locked.
     deny: 5
-    # This variable represents the number of password change cycles, after which
-    # an user can re-use a password.
-    # CIS requires a value of 5 or more.
     remember: 5
 
 # UID settings for interactive users
 # These are discovered via logins.def if set true
 discover_int_uid: false
-### Controls:
-# - 5.6.2 -  Ensure system accounts are secured
-# - 6.2.10 - Ensure local interactive user home directories exist
-# - 6.2.11 - Ensure local interactive users own their home directories
-# This variable sets the minimum number from which to search for UID
-# Note that the value will be dynamically overwritten if variable `dicover_int_uid` has
-# been set to `true`.
 min_int_uid: 1000
-### Controls:
-# - 6.2.10 - Ensure local interactive user home directories exist
-# - 6.2.11 - Ensure local interactive users own their home directories
-# This variable sets the maximum number at which the search stops for UID
-# Note that the value will be dynamically overwritten if variable `dicover_int_uid` has
-# been set to `true`.
 max_int_uid: 65533
 
-## Control 5.3.3 - Ensure sudo log file exists
-# By default, sudo logs through syslog(3). However, to specify a custom log file, the
-# 'logfile' parameter will be used, setting it with current variable's value.
-# This variable defines the path and file name of the sudo log file.
+# 5.3.3 var log location variable
 rhel9cis_sudolog_location: "/var/log/sudo.log"
 
-## Control 5.3.6 -Ensure sudo authentication timeout is configured correctly
-# This variable sets the duration (in minutes) during which a user's authentication credentials
-# are cached after successfully authenticating using "sudo". This allows the user to execute
-# multiple commands with elevated privileges without needing to re-enter their password for each
-# command within the specified time period. CIS requires a value of at most 15 minutes.
+#### 5.3.6
 rhel9cis_sudo_timestamp_timeout: 15
 
-## Control 5.4.2 - authselect and faillock
+### 5.4.2 authselect and faillock
 ## This option is used at your own risk it will enable faillock for users
 ## Only to be used on a new clean system if not using authselect
-## THIS CAN BREAK ACCESS EVEN FOR ROOT - PLEASE UNDERSTAND RISKS !
+## THIS CAN BREAK ACCESS EVEN FOR ROOT - UNDERSTAND RISKS ##
 rhel9cis_add_faillock_without_authselect: false
-# This needs to be set to 'ACCEPT'(as string), besides setting 'rhel9cis_add_faillock_without_authselect'
-# to 'true', in order to include the 'with-failock' option to the current authselect profile.
+# This needs to be set to ACCEPT
 rhel9cis_5_4_2_risks: NEVER
 
-## Control 5.6.3 - Ensure default user shell timeout is 900 seconds or less
+# RHEL-09-5.4.5
 # Session timeout setting file (TMOUT setting can be set in multiple files)
 # Timeout value is in seconds. (60 seconds * 10 = 600)
 rhel9cis_shell_session_timeout:
-    # This variable specifies the path of the timeout setting file.
-    # (TMOUT setting can be set in multiple files, but only one is required for the
-    # rule to pass. Options are:
-    # - a file in `/etc/profile.d/` ending in `.s`,
-    # - `/etc/profile`, or
-    # - `/etc/bash.bashrc`.
     file: /etc/profile.d/tmout.sh
-    # This variable represents the amount of seconds a command or process is allowed to
-    # run before being forcefully terminated.
-    # CIS requires a value of at most 900 seconds.
     timeout: 600
-
-## Control 5.6.1.5 - Ensure all users last password change date is in the past
-# Allow ansible to expire password for account with a last changed date in the future. Setting it
-# to 'false' will just display users in violation, while 'true' will expire those users passwords.
+# RHEL-09-5.4.1.5 Allow ansible to expire password for account with a last changed date in the future. False will just display users in violation, true will expire those users passwords
 rhel9cis_futurepwchgdate_autofix: true
 
-## Control 5.3.7 - Ensure access to the 'su' command is restricted
-# This variable determines the name of the group of users that are allowed to use the su command.
-# CIS requires that such a group be CREATED(named according to site policy) and be kept EMPTY.
+# 5.3.7
 rhel9cis_sugroup: nosugroup
 
 ## Section6 vars
 
-## Control 6.1.15 - Audit system file permissions | Create list and warning
-# The RPM package-manager has many useful options. For example, using option:
-#  - '-V': RPM can automatically check if system packages are correctly installed
-#  - '-qf': RPM can be used to determine which package a particular file belongs to
-# Auditing system file-permissions takes advantage of the combination of those two options and, therefore, is able to
-# detect any discrepancy regarding installed packages, redirecting the output of this combined
-# command into a specific file. If no output is returned, the package is installed correctly.
-# Current variable stores the preferred absolute filepath for such a file, therefore if this file
-# contains any lines, an alert message will be generated to warn about each discrepancy.
+# RHEL-09_6.1.1
 rhel9cis_rpm_audit_file: /var/tmp/rpm_file_check
 
-## Control 6.1.9 - Ensure no world writable files exist
-# Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable.
+# RHEL-09_6.1.10 Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable
 rhel9cis_no_world_write_adjust: true
-
 rhel9cis_passwd_label: "{{ (this_item | default(item)).id }}: {{ (this_item | default(item)).dir }}"
 
-## Control 6.2.16 - Ensure local interactive user dot files are not group or world writable
-# This boolean variable governs if current role should follow filesystem links for changes to
-# user home directory.
+# 6.2.16
+## Dont follow symlinks for changes to user home directory thanks to @dulin-gnet and comminty for rhel8-cis reedbacj
 rhel_09_6_2_16_home_follow_symlinks: false
-# thanks to @dulin-gnet and community for rhel8-cis feedback.
 
 #### Goss Configuration Settings ####
 # Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -853,6 +853,12 @@ rhel9cis_auditd:
     # CIS prescribes the value `keep_logs`.
     max_log_file_action: keep_logs
 
+##  Control 4.1.1.4 - Ensure rhel9cis_audit_back_log_limit is sufficient
+# This variable represents the audit backlog limit, i.e., the maximum number of audit records that the
+# system can buffer in memory, if the audit subsystem is unable to process them in real-time.
+# Buffering in memory is useful in situations, where the audit system is overwhelmed
+# with incoming audit events, and needs to temporarily store them until they can be processed.
+# This variable should be set to a sufficient value. The CIS baseline recommends at least `8192` as value.
 # This value governs if the below extra-vars for auditd should be used by the role
 rhel9cis_auditd_extra_conf_usage: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,19 @@
 ---
 # defaults file for rhel9-cis
+# WARNING:
+# These values may be overriden by other vars-setting options(e.g. like the below 'container_vars_file'), as explained here:
+# https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable
 
+## Usage on containerized images
+# The role discovers dynamically (in tasks/main.yml) whether it
+# is executed on a container image and sets the variable
+# system_is_container the true. Otherwise, the default value
+# 'false' is left unchanged.
 system_is_container: false
+# The filename of the existing yml file in role's  'vars/' sub-directory
+# to be used for managing the role-behavior when a container was detected:
+# (de)activating rules or for other tasks(e.g. disabling Selinux or a specific
+# firewall-type).
 container_vars_file: is_container.yml
 # rhel9cis is left off the front of this var for consistency in testing pipeline
 # system_is_ec2 toggle will disable tasks that fail on Amazon EC2 instances. Set true to skip and false to run tasks
@@ -11,6 +23,10 @@ system_is_ec2: false
 # Supported OSs will not need for this to be changed - see README e.g. CentOS
 os_check: true
 
+## Switching on/off specific baseline sections
+# These variables govern whether the tasks of a particular section are to be executed when running the role.
+# E.g: If you want to execute the tasks of Section 1 you should set the "_section1" variable to true.
+# If you do not want the tasks from that section to get executed you simply set the variable to "false".
 rhel9cis_section1: true
 rhel9cis_section2: true
 rhel9cis_section3: true
@@ -25,7 +41,12 @@ rhel9cis_section6: true
 rhel9cis_level_1: true
 rhel9cis_level_2: true
 
+## Section 1.6 - Mandatory Access Control
+# This variable governs whether SELinux is disabled or not. If SELinux is NOT DISABLED by setting
+# 'rhel9cis_selinux_disable' to 'true', the 1.6 subsection will be executed.
 rhel9cis_selinux_disable: false
+# This variable is used in a preliminary task, handling grub2 paths either in case of
+# UEFI boot('/etc/grub2-efi.cfg') or in case of BIOS legacy-boot('/etc/grub2.cfg').
 rhel9cis_legacy_boot: false
 
 ## Python Binary
@@ -39,7 +60,8 @@ benchmark_version: 'v1.0.0'
 
 benchmark: RHEL9-CIS
 
-# Whether to skip the reboot
+# Whether to skip the system reboot before audit
+# System will reboot if false, can give better audit results
 skip_reboot: true
 
 # default value will change to true but wont reboot if not enabled but will error
@@ -48,44 +70,65 @@ change_requires_reboot: false
 ##########################################
 ### Goss is required on the remote host ###
 ## Refer to vars/auditd.yml for any other settings ##
+#### Basic external goss audit enablement settings ####
+#### Precise details - per setting can be found at the bottom of this file ####
 
-# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
+## Audit setup
+# Audits are carried out using Goss. This variable
+# determines whether execution of the role prepares for auditing
+# by installing the required binary.
 setup_audit: false
 
-# enable audits to run - this runs the audit and get the latest content
+## Enable audits to run - this runs the audit and get the latest content
+# This variable governs whether the audit using the
+# separately maintained audit role using Goss
+# is carried out.
 run_audit: false
 
 # Only run Audit do not remediate
 audit_only: false
-# As part of audit_only
-# This will enable files to be copied back to control node
+# This will enable files to be copied back to control node(part of audit_only)
 fetch_audit_files: false
-# Path to copy the files to will create dir structure
+# Path to copy the files to will create dir structure(part of audit_only)
 audit_capture_files_dir: /some/location to copy to on control node
 
-# How to retrieve audit binary
-# Options are copy or download - detailed settings at the bottom of this file
-# you will need to access to either github or the file already dowmloaded
+## How to retrieve audit binary(Goss)
+# Options are 'copy' or 'download' - detailed settings at the bottom of this file
+# - if 'copy':
+#    - the filepath mentioned via the below 'audit_bin_copy_location' var will be used to access already downloaded Goss
+# - if 'download':
+#    - the GitHub Goss-releases URL will be used for a fresh-download, via 'audit_bin_url' and 'audit_pkg_arch_name' vars
 get_audit_binary_method: download
 
-## if get_audit_binary_method - copy the following needs to be updated for your environment
+## if get_audit_binary_method is 'copy', the following var needs to be updated for your environment
 ## it is expected that it will be copied from somewhere accessible to the control node
 ## e.g copy from ansible control node to remote host
 audit_bin_copy_location: /some/accessible/path
 
-# how to get audit files onto host options
+## How to retrieve the audit role
+# The role for auditing is maintained separately.
+# This variable specifies the method of how to get the audit role
 # options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
+# onto the system. The options are as follows:
+# - 'git': clone audit content from GitHub REPOSITORY, set up via `audit_file_git` var, and
+#          VERSION(e.g. branch, tag name), set up via `audit_git_version` var.
+# - 'copy': copy from path as specified in variable `audit_conf_copy`.
+# - 'archive': same as 'copy', only that the specified filepath needs to be unpacked.
+# - 'get_url': Download from url as specified in variable `audit_files_url`
 audit_content: git
 
-# archive or copy:
+# This variable(only used when 'audit_content' is 'copy' or 'archive') should
+# contain the filepath with audit-content to be copied/unarchived on server:
 audit_conf_copy: "some path to copy from"
 
-# get_url:
+# This variable(only used when 'audit_content' is 'get_url') should
+# contain the URL from where the audit-content must be downloaded on server:
 audit_files_url: "some url maybe s3?"
 
 # Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
 audit_run_heavy_tests: true
 
+# Timeout for those cmds that take longer to run where timeout set
 # This variable specifies the timeout (in ms) for audit commands that
 # take a very long time: if a command takes too long to complete,
 # it will be forcefully terminated after the specified duration.
@@ -97,7 +140,9 @@ audit_cmd_timeout: 120000
 # the CIS benchmark documents.
 # PLEASE NOTE: These work in coordination with the section # group variables and tags.
 # You must enable an entire section in order for the variables below to take effect.
-# Section 1 rules
+
+# Section 1 is Initial setup (FileSystem Configuration, Configure Software Updates, Filesystem Integrity Checking, Secure Boot Settings,
+# Additional Process Hardening, Mandatory Access Control, Command Line Warning Banners, and GNOME Display Manager)
 rhel9cis_rule_1_1_1_1: true
 rhel9cis_rule_1_1_1_2: true
 rhel9cis_rule_1_1_2_1: true
@@ -170,7 +215,7 @@ rhel9cis_rule_1_8_10: true
 rhel9cis_rule_1_9: true
 rhel9cis_rule_1_10: true
 
-# Section 2 rules
+# Section 2 rules are controling Services (Special Purpose Services, and service clients)
 rhel9cis_rule_2_1_1: true
 rhel9cis_rule_2_1_2: true
 rhel9cis_rule_2_2_1: true
@@ -197,7 +242,7 @@ rhel9cis_rule_2_3_3: true
 rhel9cis_rule_2_3_4: true
 rhel9cis_rule_2_4: true
 
-# Section 3 rules
+# Section 3 rules are used for securely configuring the network configuration(kernel params, ACL, Firewall settings)
 rhel9cis_rule_3_1_1: true
 rhel9cis_rule_3_1_2: true
 rhel9cis_rule_3_1_3: true
@@ -222,7 +267,8 @@ rhel9cis_rule_3_4_2_5: true
 rhel9cis_rule_3_4_2_6: true
 rhel9cis_rule_3_4_2_7: true
 
-# Section 4 rules
+# Section 4 rules are Logging and Auditing (Configure System Accounting (auditd),
+# Configure Data Retention, and Configure Logging)
 rhel9cis_rule_4_1_1_1: true
 rhel9cis_rule_4_1_1_2: true
 rhel9cis_rule_4_1_1_3: true
@@ -281,7 +327,8 @@ rhel9cis_rule_4_2_2_7: true
 rhel9cis_rule_4_2_3: true
 rhel9cis_rule_4_3: true
 
-# Section 5 rules
+# Section 5 rules control Access, Authentication, and Authorization (Configure time-based job schedulers,
+# Configure sudo, Configure SSH Server, Configure PAM and User Accounts and Environment)
 rhel9cis_rule_5_1_1: true
 rhel9cis_rule_5_1_2: true
 rhel9cis_rule_5_1_3: true
@@ -336,7 +383,7 @@ rhel9cis_rule_5_6_4: true
 rhel9cis_rule_5_6_5: true
 rhel9cis_rule_5_6_6: true
 
-# Section 6 rules
+# Section 6 rules controls System Maintenance (System File Permissions and User and Group Settings)
 rhel9cis_rule_6_1_1: true
 rhel9cis_rule_6_1_2: true
 rhel9cis_rule_6_1_3: true
@@ -371,140 +418,367 @@ rhel9cis_rule_6_2_16: true
 
 ## Section 1 vars
 
-#### 1.1.2
-# These settings go into the /etc/fstab file for the /tmp mount settings
-# The value must contain nosuid,nodev,noexec to conform to CIS standards
-# rhel9cis_tmp_tmpfs_settings: "defaults,rw,nosuid,nodev,noexec,relatime 0 0"
-# If set true uses the tmp.mount service else using fstab configuration
+## Control 1.1.2
+# If set to `true`, rule will be implemented using the `tmp.mount` systemd-service,
+# otherwise fstab configuration will be used.
+# These /tmp settings will include nosuid,nodev,noexec to conform to CIS standards.
 rhel9cis_tmp_svc: false
 
-#### 1.1.9
+## Control 1.1.9
 rhel9cis_allow_autofs: false
 
-# 1.2.1
+## Control 1.2.1
 # This is the login information for your RedHat Subscription
 # DO NOT USE PLAIN TEXT PASSWORDS!!!!!
 # The intent here is to use a password utility like Ansible Vault here
 rhel9cis_rh_sub_user: user
 rhel9cis_rh_sub_password: password  # pragma: allowlist secret
 
-# 1.2.2
+## Control 1.2.2
 # Do you require rhnsd
 # RedHat Satellite Subscription items
 rhel9cis_rhnsd_required: false
 
-# 1.2.4 repo_gpgcheck
+## Control 1.2.4
+# When installing RHEL from authorized Red Hat source, RHEL will come with default YUM repository. NOT having a default YUM
+# repo ('rhel9cis_rhel_default_repo' set as 'false'), in conjunction with 'rhel9cis_rule_enable_repogpg' set as 'True', will enable the tasks
+# which check the GPG signatures for all the individual YUM repositories.
 rhel9cis_rhel_default_repo: true
+## Control 1.2.4
+# When 'rhel9cis_rule_enable_repogpg' is set to 'true'(in conjunction with 'rhel9cis_rhel_default_repo':'false'), conditions are met for
+# enabling the GPG signatures-check for all the individual YUM repositories. If GPG signatures-check is enabled on repositories which do not
+# support it(like RedHat), installation of packages will fail.
 rhel9cis_rule_enable_repogpg: true
 
-# 1.4.1 Bootloader password
+## Control 1.4.1
+# This variable will store the hashed GRUB bootloader password to be stored in '/boot/grub2/user.cfg' file. The default value
+# must be changed to a value that may be generated with this command 'grub2-mkpasswd-pbkdf2' and must comply with
+# this format: 'grub.pbkdf2.sha512.<Rounds>.<Salt>.<Checksum>'
 rhel9cis_bootloader_password_hash: 'grub.pbkdf2.sha512.10000.9306A36764A7BEA3BF492D1784396B27F52A71812E9955A58709F94EE70697F9BD5366F36E07DEC41B52279A056E2862A93E42069D7BBB08F5DFC2679CD43812.6C32ADA5449303AD5E67A4C150558592A05381331DE6B33463469A236871FA8E70738C6F9066091D877EF88A213C86825E093117F30E9E1BF158D0DB75E7581B'  # pragma: allowlist secret
 rhel9cis_bootloader_password: random  # pragma: allowlist secret
+## Control 1.4.1
+# This variable governs whether a bootloader password should be set in '/boot/grub2/user.cfg' file.
 rhel9cis_set_boot_pass: true
 
-# 1.8 Gnome Desktop
+## Control 1.8.x - Settings for GDM
+# This variable specifies the GNOME configuration database file to which configurations are written.
+# (See "https://help.gnome.org/admin/system-admin-guide/stable/dconf-keyfiles.html.en")
+# The default database is 'local'.
 rhel9cis_dconf_db_name: local
-rhel9cis_screensaver_idle_delay: 900  # Set max value for idle-delay in seconds (between 1 and 900)
-rhel9cis_screensaver_lock_delay: 5  # Set max value for lock-delay in seconds (between 0 and 5)
+# This variable governs the number of seconds of inactivity before the screen goes blank.
+# Set max value for idle-delay in seconds (between 1 and 900)
+rhel9cis_screensaver_idle_delay: 900
+# This variable governs the number of seconds the screen remains blank before it is locked.
+# Set max value for lock-delay in seconds (between 0 and 5)
+rhel9cis_screensaver_lock_delay: 5
 
-# 1.10/1.11 Set crypto policy (LEGACY, DEFAULT, FUTURE, FIPS)
-# Control 1.10 states do not use LEGACY and control 1.11 says to use FUTURE or FIPS.
+## Control 1.10
+# This variable contains the value to be set as the system-wide crypto policy. Current rule enforces NOT USING
+# 'LEGACY' value(as it is less secure, it just ensures compatibility with legacy systems), therefore
+# possible values for this variable are, as explained by RedHat docs:
+#  -'DEFAULT': reasonable default policy for today's standards (balances usability and security)
+#  -'FUTURE': conservative security level that is believed to withstand any near-term future attacks
+#  -'FIPS': A level that conforms to the FIPS140-2 requirements
 rhel9cis_crypto_policy: 'DEFAULT'
-# Added module to be allowed as default setting (Allowed options in vars/main.yml)
+## Control 1.10
+# This variable contains the value of the crypto policy module(combinations of policies and
+# sub-policies) to be allowed as default setting. Allowed options are defined in 'vars/main.yml' file,
+# using 'rhel9cis_allowed_crypto_policies_modules' variable.
 rhel9cis_crypto_policy_module: ''
 
 # System network parameters (host only OR host and router)
+# This variable governs whether specific CIS rules
+# concerned with acceptance and routing of packages are skipped.
 rhel9cis_is_router: false
 
-# IPv6 required
+## IPv6 requirement toggle
+# This variable governs whether ipv6 is enabled or disabled.
 rhel9cis_ipv6_required: true
 
-# AIDE
+## Control 1.3.1 - allow aide to be configured
+# AIDE is a file integrity checking tool, similar in nature to Tripwire.
+# While it cannot prevent intrusions, it can detect unauthorized changes
+# to configuration files by alerting when the files are changed. Review
+# the AIDE quick start guide and AIDE documentation before proceeding.
+# By setting this variable to `true`, all of the settings related to AIDE will be applied!
 rhel9cis_config_aide: true
-# AIDE cron settings
+
+## Control 1.3.2 AIDE cron settings
+# These are the crontab settings for periodical checking of the filesystem's integrity using AIDE.
+# The sub-settings of this variable provide the parameters required to configure
+# the cron job on the target system.
+# Cron is a time-based job scheduling program in Unix OS, which allows tasks to be scheduled
+# and executed automatically at a certain point in time.
 rhel9cis_aide_cron:
+    # This variable represents the user account under which the cron job for AIDE will run.
     cron_user: root
+    # This variable represents the path to the AIDE crontab file.
     cron_file: /etc/cron.d/aide_cron
+    # This variable represents the actual command or script that the cron job
+    # will execute for running AIDE.
     aide_job: '/usr/sbin/aide --check'
+    # These variables define the schedule for the cron job
+    # This variable governs the minute of the time of day when the AIDE cronjob is run.
+    # It must be in the range `0-59`.
     aide_minute: 0
+    # This variable governs the hour of the time of day when the AIDE cronjob is run.
+    # It must be in the range `0-23`.
     aide_hour: 5
+    # This variable governs the day of the month when the AIDE cronjob is run.
+    # `*` signifies that the job is run on all days; furthermore, specific days
+    # can be given in the range `1-31`; several days can be concatenated with a comma.
+    # The specified day(s) can must be in the range  `1-31`.
     aide_day: '*'
+    # This variable governs months when the AIDE cronjob is run.
+    # `*` signifies that the job is run in every month; furthermore, specific months
+    # can be given in the range `1-12`; several months can be concatenated with commas.
+    # The specified month(s) can must be in the range  `1-12`.
     aide_month: '*'
+    # This variable governs the weekdays, when the AIDE cronjob is run.
+    # `*` signifies that the job is run on all weekdays; furthermore, specific weekdays
+    # can be given in the range `0-7` (both `0` and `7` represent Sunday); several weekdays
+    # can be concatenated with commas.
     aide_weekday: '*'
 
-# SELinux policy
+## Control 1.6.1.3|4|5 - SELinux policy settings
+# This selects type of policy; targeted or mls( multilevel )
+# mls should not be used, since it will disable unconfined policy module
+# and may prevent some services from running. Requires SELinux not being disabled (by
+# having 'rhel9cis_selinux_disable' var set as 'true'), otherwise setting will be ignored.
 rhel9cis_selinux_pol: targeted
-# chose onf or enfocing or permissive
+## Control 1.6.1.3|4 - SELinux configured and not disabled
+# This variable contains a specific SELinux mode, respectively:
+#  - 'enforcing':  SELinux policy IS enforced, therefore denies operations based on SELinux policy
+# rules. If system was installed with SELinux, this is enabled by default.
+#  - 'permissive': SELinux policy IS NOT enforced, therefore does NOT deny any operation, only
+# logs AVC(Access Vector Cache) messages. RedHat docs suggest it "can be used
+# briefly to check if SELinux is the culprit in preventing your application
+# from working".
+# CIS expects enforcing since permissive allows operations that might compromise the system.
+# Even though logging still occurs.
 rhel9cis_selinux_enforce: enforcing
 
 # Whether or not to run tasks related to auditing/patching the desktop environment
 
-## 2. Services
+## Section 2. Services
 
-### 2.1 Time Synchronization
-#### 2.1.2 Time Synchronization servers - used in template file chrony.conf.j2
+## Section 2.1 Time Synchronization
+
+## Control 2.1.2 Time Synchronization servers - used in template file chrony.conf.j2
+# The following variable represents a list of time servers used
+# for configuring chrony, timesyncd, and ntp.
+# Each list item contains two settings, `name` (the domain name of the server) and synchronization `options`.
+# The default setting for the `options` is `minpoll` but `iburst` can be used, please refer to the documentation
+# of the time synchronization mechanism you are using.
 rhel9cis_time_synchronization_servers:
     - 0.pool.ntp.org
     - 1.pool.ntp.org
     - 2.pool.ntp.org
     - 3.pool.ntp.org
+## Control 2.1.2 - Time Synchronization servers
+# This variable should contain the default options to be used for every NTP server hostname defined
+# within the 'rhel9cis_time_synchronization_servers' var.
 rhel9cis_chrony_server_options: "minpoll 8"
+# This variable, if set to 'true'(default), will inform the kernel the system clock is kept synchronized
+# and the kernel will update the real-time clock every 11 minutes. Otherwise, if 'rtcsync' option is
+# disabled, chronyd will not be in sync(kernel discipline is disabled, 11 minutes mode will be off).
 rhel9cis_chrony_server_rtcsync: false
+# This variable configures the values to be used by chronyd to gradually correct any time offset,
+# by slowing down/speeding up the clock. An example of this directive usage would be:
+# 'makestep 1000 10'.
+# Step the system clock:
+#   - IF the adjustment is larger than 1000 seconds
+#   - but ONLY IN the first ten clock updates
 rhel9cis_chrony_server_makestep: "1.0 3"
+# This variable configures the minimum number of sources that need to be considered as selectable in the source
+# selection algorithm before the local clock is updated. Setting minsources to a larger number can be used to
+# improve the reliability, because multiple sources will need to correspond with each other.
 rhel9cis_chrony_server_minsources: 2
 
-### 2.2 Special Purposes
-##### Service configuration booleans set true to keep service
-rhel9cis_gui: false
-rhel9cis_avahi_server: false
-rhel9cis_cups_server: false
-rhel9cis_dhcp_server: false
-rhel9cis_dns_server: false
-rhel9cis_dnsmasq_server: false
-rhel9cis_vsftpd_server: false
-rhel9cis_tftp_server: false
-rhel9cis_httpd_server: false
-rhel9cis_nginx_server: false
-rhel9cis_dovecot_server: false
-rhel9cis_imap_server: false
-rhel9cis_samba_server: false
-rhel9cis_squid_server: false
-rhel9cis_snmp_server: false
-rhel9cis_telnet_server: false
-rhel9cis_is_mail_server: false
-# Note the options
-# Packages are used for client services and Server- only remove if you dont use the client service
-#
+## Section 2.2 Special Purposes
+# Service configuration variables (boolean).
+# Set the respective variable to true to keep the service,
+# otherwise the service is stopped and disabled
 
+## Control 1.8.10-10, 2.2.1
+# This variable governs whether rules dealing with GUI specific packages(and/or their settings) should
+# be executed either to:
+# - secure GDM, if GUI is needed('rhel9cis_gui: true')
+# - or remove GDM and X-Windows-system, if no GUI is needed('rhel9cis_gui: false')
+rhel9cis_gui: false
+## Control 2.2.2 - Ensure Avahi Server is not installed
+# This variable, when set to false, will specify that Avahi Server packages should be uninstalled.
+rhel9cis_avahi_server: false
+## Control 2.2.3 -  Ensure CUPS is not installed
+# This variable, when set to false, will specify that CUPS(Common UNIX Printing System) package should be uninstalled.
+rhel9cis_cups_server: false
+## Control 2.2.4 - Ensure DHCP Server is not installed
+# This variable, when set to false, will specify that DHCP server package should be uninstalled.
+rhel9cis_dhcp_server: false
+## Control 2.2.5 - Ensure DNS Server is not installed
+# This variable, when set to false, will specify that DNS server package should be uninstalled.
+rhel9cis_dns_server: false
+## Control 2.2.14 - Ensure dnsmasq is not installed
+# This variable, when set to false, will specify that dnsmasq package should be uninstalled.
+rhel9cis_dnsmasq_server: false
+## Control 2.2.6 - Ensure VSFTP Server is not installed
+# This variable, when set to false, will specify that VSFTP server package should be uninstalled.
+rhel9cis_vsftpd_server: false
+## Control 2.2.7 - Ensure TFTP Server is not installed
+# This variable, when set to false, will specify that TFTP server package should be uninstalled.
+rhel9cis_tftp_server: false
+## Control 2.2.8 - Ensure a web server is not installed - HTTPD
+# This variable, when set to false, will specify that webserver packages(HTTPD) should be uninstalled.
+rhel9cis_httpd_server: false
+## Control 2.2.8 - Ensure a web server is not installed - NGINX
+# This variable, when set to false, will specify that webserver packages(NGINX) should be uninstalled.
+rhel9cis_nginx_server: false
+## Control 2.2.9 - Ensure IMAP and POP3 server is not installed - dovecot
+# This variable, when set to false, will specify that IMAP and POP3 servers(dovecot) should be uninstalled.
+rhel9cis_dovecot_server: false
+## Control 2.2.9 - Ensure IMAP and POP3 server is not installed - cyrus-imapd
+# This variable, when set to false, will specify that IMAP and POP3 servers(cyrus-imapd) should be uninstalled.
+rhel9cis_imap_server: false
+## Control 2.2.10 - Ensure Samba is not enabled
+# This variable, when set to false, will specify that 'samba' package should be uninstalled.
+rhel9cis_samba_server: false
+## Control 2.2.11 - Ensure HTTP Proxy Server is not installed
+# This variable, when set to false, will specify that 'squid' package should be uninstalled.
+rhel9cis_squid_server: false
+## Control 2.2.12 - Ensure net-snmp is not installed
+# This variable, when set to false, will specify that 'net-snmp' package should be uninstalled.
+rhel9cis_snmp_server: false
+## Control 2.2.13 - Ensure telnet-server is not installed
+# This variable, when set to false, will specify that 'telnet-server' package should be uninstalled.
+rhel9cis_telnet_server: false
+## Control 2.2.15 - Ensure mail transfer agent is configured for local-only mode
+# This variable, when system is NOT a mailserver, will configure Postfix to listen only on the loopback interface(the virtual
+# network interface that the server uses to communicate internally.
+rhel9cis_is_mail_server: false
+
+# Note the options
+# Client package configuration variables.
+# Packages are used for client services and Server- only remove if you dont use the client service
+# Set the respective variable to `true` to keep the
+# client package, otherwise it is uninstalled (false).
+
+## Control 2.2.16 - Ensure nfs-utils is not installed or the nfs-server service is masked"
+# This variable specifies if the usage of NFS SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
+# NFS(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_nfs_service') with current one, respectively:
+# - if Server IS NOT needed('false') and:
+#    - Service IS NOT needed('rhel9cis_use_nfs_service: false'): 'nfs-utils' package will be removed
+#    - Service IS needed('rhel9cis_use_nfs_service: true'): impossible to need the service without the server
+# - if Server IS needed('true') and:
+#    - Service IS NOT needed('rhel9cis_use_nfs_service: false'): 'nfs-server' service will be masked
+#    - Service IS needed('rhel9cis_use_nfs_service: true'): Rule will be SKIPPED.
+#  | Server  | Service | Result                                                    |
+#  |---------|---------|-----------------------------------------------------------|
+#  | false   | false   | Remove package                                            |
+#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
+#  | true    | false   | Mask 'service'                                            |
+#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_nfs_server: false
+## Control 2.2.16 - Ensure nfs-utils is not installed or the nfs-server service is masked.
+# This variable specifies if the usage of NFS SERVICE is needed. If it's:
+#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
+#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being
+#    controlled by the var used in conjunction with current one:
+#          - removing 'nfs-utils' package('rhel9cis_use_nfs_server' set to 'false')
+#          - masking the 'nfs-server' service('rhel9cis_use_nfs_server' set to 'true')
 rhel9cis_use_nfs_service: false
 
+## Control 2.2.17 - Ensure rpcbind is not installed or the rpcbind services are masked
+# This variable specifies if the usage of RPC SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
+# RPC(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_rpc_service') with current one, respectively:
+# - if Server IS NOT needed('false') and:
+#    - Service IS NOT needed('rhel9cis_use_rpc_service: false'): 'rpcbind' package will be removed
+#    - Service IS needed('rhel9cis_use_rpc_service: true'): impossible to need the service without the server
+# - if Server IS needed('true') and:
+#    - Service IS NOT needed('rhel9cis_use_rpc_service: false'): 'rpcbind.socket' service will be masked
+#    - Service IS needed('rhel9cis_use_rpc_service: true'): Rule will be SKIPPED.
+#  | Server  | Service | Result                                                    |
+#  |---------|---------|-----------------------------------------------------------|
+#  | false   | false   | Remove package                                            |
+#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
+#  | true    | false   | Mask 'service'                                            |
+#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_rpc_server: false
+## Control 2.2.17 - Ensure rpcbind is not installed or the rpcbind services are masked
+# This variable specifies if the usage of RPC SERVICE is needed. If it's:
+#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
+#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being controlled by the var
+#     used in conjunction with current one:
+#          - removing 'rpcbind' package('rhel9cis_use_rpc_server' set to 'false')
+#          - masking the 'rpcbind.socket' service('rhel9cis_use_rpc_server' set to 'true')
 rhel9cis_use_rpc_service: false
 
+## Control 2.2.18 - Ensure rsync service is not enabled
+# This variable specifies if the usage of RSYNC SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
+# RSYNC(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_rsync_service') with current one, respectively:
+# - if Server IS NOT needed('false') and:
+#    - Service IS NOT needed('rhel9cis_use_rsync_service: false'): 'rsync-daemon' package will be removed
+#    - Service IS needed('rhel9cis_use_rsync_service: true'): impossible to need the service without the server
+# - if Server IS needed('true') and:
+#    - Service IS NOT needed('rhel9cis_use_rsync_service: false'): 'rsyncd' service will be masked
+#    - Service IS needed('rhel9cis_use_rsync_service: true'): Rule will be SKIPPED.
+#  | Server  | Service | Result                                                    |
+#  |---------|---------|-----------------------------------------------------------|
+#  | false   | false   | Remove package                                            |
+#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
+#  | true    | false   | Mask 'service'                                            |
+#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_rsync_server: false
+## Control 2.2.18 - Ensure rsync service is not enabled
+# This variable specifies if the usage of RSYNC SERVICE is needed. If it's:
+#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
+#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being controlled by the var
+#     used in conjunction with current one:
+#          - removing 'rsync-daemon' package('rhel9cis_use_rsync_server' set to 'false')
+#          - masking the 'rsyncd' service('rhel9cis_use_rsync_server' set to 'true')
 rhel9cis_use_rsync_service: false
 
-#### 2.3 Service clients
+## Section 2.3 Service clients
+
+## Control - 2.3.1 - Ensure telnet client is not installed
+# Set this variable to `true` to keep package `telnet`; otherwise, the package is uninstalled.
 rhel9cis_telnet_required: false
+## Control - 2.3.2 - Ensure LDAP client is not installed
+# Set this variable to `true` to keep package `openldap-clients`; otherwise, the package is uninstalled.
 rhel9cis_openldap_clients_required: false
+## Control - 2.3.3 - Ensure FTP client is not installed
+# Set this variable to `true` to keep package `tftp`; otherwise, the package is uninstalled.
 rhel9cis_tftp_client: false
+## Control - 2.3.4 - Ensure FTP client is not installed
+# Set this variable to `true` to keep package `ftp`; otherwise, the package is uninstalled.
 rhel9cis_ftp_client: false
 
-## Section3 vars
+## Section 3 vars
 ## Sysctl
+
+# This variable governs if the task which updates sysctl(including sysctl reload) is executed.
+# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_sysctl_update: false
+# This variable governs if the task which flushes the IPv4 routing table is executed(forcing subsequent connections to
+# use the new configuration).
+# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_flush_ipv4_route: false
+# This variable governs if the task which flushes the IPv6 routing table is executed(forcing subsequent connections to
+# use the new configuration).
+# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_flush_ipv6_route: false
 
-### Firewall Service - either firewalld, iptables, or nftables
+### Firewall Service to install and configure - Options are:
+# 1) either 'firewalld'
+# 2) or 'nftables'
 #### Some control allow for services to be removed or masked
 #### The options are under each heading
 #### absent = remove the package
 #### masked = leave package if installed and mask the service
 rhel9cis_firewall: firewalld
 
-##### firewalld
+## Control 3.4.2.1 - Ensure firewalld default zone is set
+# This variable will set the firewalld default zone(that is used for everything that is not explicitly bound/assigned
+# to another zone): if there is no zone assigned to a connection, interface or source, only the default zone is used.
 rhel9cis_default_zone: public
 
 # These settings are added to demonstrate how this update can be done (eventually will require a new control)
@@ -512,24 +786,63 @@ rhel9cis_firewalld_ports:
     - number: 80
       protocol: tcp
 
-#### nftables
+## Control 3.4.2.2 - Ensure at least one nftables table exists
+# This variable governs if a table will be automatically created in nftables. Without a table (no default one), nftables
+# will not filter network traffic, so if this variable is set to 'false' and no tables exist, an alarm will be triggered!
 rhel9cis_nft_tables_autonewtable: true
+## Controls 3.4.2.{2|3|4|6|7} nftables
+# This variable stores the name of the table to be used when configuring nftables(creating chains, configuring loopback
+# traffic, established connections, default deny). If 'rhel9cis_nft_tables_autonewtable' is set as true, a new table will
+# be created using as name the value stored by this variable.
 rhel9cis_nft_tables_tablename: filter
+## Control 3.4.2.3 - Ensure nftables base chains exist
+# This variable governs if a nftables base chain(entry point for packets from the networking stack) will be automatically
+# created, if needed. Without a chain, a hook for input, forward, and delete, packets that would flow through those
+# chains will not be touched by nftables.
 rhel9cis_nft_tables_autochaincreate: true
 
-# Warning Banner Content (issue, issue.net, motd)
+## Controls:
+# - 1.7.1 - Ensure message of the day is configured properly
+# - 1.7.2 - Ensure local login warning banner is configured properly
+# - 1.7.3 - Ensure remote login warning banner is configured properly
+# This variable  stores the content for the Warning Banner(relevant for issue, issue.net, motd).
 rhel9cis_warning_banner: Authorized uses only. All activity may be monitored and reported.
 # End Banner
 
 ## Section4 vars
 ### 4.1 Configure System Accounting
 #### 4.1.2 Configure Data Retention
+## Controls what actions, when log files fill up
+# This variable controls how the audit system behaves when
+# log files are getting too full and space is getting too low.
 rhel9cis_auditd:
+    # This variable tells the system what action to take when the system has detected
+    # that it is starting to get low on disk space. Options are the same as for `admin_space_left_action`.
     space_left_action: email
+    # This variable should contain a valid email address or alias(default value is root),
+    # which will be used to send a warning when configured action is 'email'.
     action_mail_acct: root
+    # This variable determines the action the audit system should take when disk
+    # space runs low.
+    # The options for setting this variable are as follows:
+    # - `ignore`: the system does nothing when presented with the aforementioned issue;
+    # - `syslog`: a message is sent to the system log about disk space running low;
+    # - `suspend`: the system suspends recording audit events until more space is available;
+    # - `halt`: the system is halted when disk space is critically low.
+    # - `single`: the audit daemon will put the computer system in single user mode
+    # CIS prescribes either `halt` or `single`.
     admin_space_left_action: halt
     # The max_log_file parameter should be based on your sites policy.
     max_log_file: 10
+    # This variable determines what action the audit system should take when the maximum
+    # size of a log file is reached.
+    # The options for setting this variable are as follows:
+    # - `ignore`: the system does nothing when the size of a log file is full;
+    # - `syslog`: a message is sent to the system log indicating the problem;
+    # - `suspend`: the system suspends recording audit events until the log file is cleared or rotated;
+    # - `rotate`: the log file is rotated (archived) and a new empty log file is created;
+    # - `keep_logs`: the system attempts to keep as many logs as possible without violating disk space constraints.
+    # CIS prescribes the value `keep_logs`.
     max_log_file_action: keep_logs
 
 ##  Control 4.1.1.4 - Ensure rhel9cis_audit_back_log_limit is sufficient
@@ -546,154 +859,390 @@ rhel9cis_auditd_extra_conf_usage: false
 # rhel9cis_auditd_extra_conf:
 #     admin_space_left: '10%'
 rhel9cis_auditd_extra_conf:
+    # This variable governs the threshold(MegaBytes) under which the audit daemon should perform a
+    # specific action to alert that the system is running low on disk space. Must be lower than
+    # the 'space_left' variable.
     admin_space_left: 50
+    # This variable governs the threshold(MegaBytes) under which the audit daemon should perform a
+    # specific action to alert that the system is running low on disk space(last chance to do something
+    # before running out of disk space). Must be lower than the 'space_left' variable.
     space_left: 75
 
-# The audit_back_log_limit value should never be below 8192
+##  Control 4.1.1.4 - Ensure rhel9cis_audit_back_log_limit is sufficient
+# This variable represents the audit backlog limit, i.e., the maximum number of audit records that the
+# system can buffer in memory, if the audit subsystem is unable to process them in real-time.
+# Buffering in memory is useful in situations, where the audit system is overwhelmed
+# with incoming audit events, and needs to temporarily store them until they can be processed.
+# This variable should be set to a sufficient value. The CIS baseline recommends at least `8192` as value.
 rhel9cis_audit_back_log_limit: 8192
 
-### 4.1.3.x audit template
+## Control 4.1.2.1 - Ensure audit log storage size is configured
+# This variable specifies the maximum size in MB that an audit log file can reach
+# before it is archived or deleted to make space for the new audit data.
+# This should be set based on your sites policy. CIS does not provide a specific value.
+rhel9cis_max_log_file_size: 10
+
+## Control 4.1.3.x - Audit template
+# This variable governs if the auditd logic should be executed(if value is true).
+# NOTE: The current default value is likely to be overriden(via 'set_fact') by other further tasks(in sub-section 'Auditd rules').
 update_audit_template: false
 
 ## Advanced option found in auditd post
+# This variable governs if defining user exceptions for auditd logging is acceptable.
 rhel9cis_allow_auditd_uid_user_exclusions: false
+# This variable contains a list of uids to be excluded(users whose actions are not logged by auditd)
+rhel9cis_auditd_uid_exclude:
+    - 1999
 
 ## Preferred method of logging
 ## Whether rsyslog or journald preferred method for local logging
-## Affects rsyslog cis 4.2.1.3 and journald cis 4.2.2.5
+## Control 4.2.1 | Configure rsyslog
+## Control 4.2.2 | Configure journald
+# This variable governs which logging service should be used, choosing between 'rsyslog'(CIS recommendation)
+# or 'journald'(only one is implemented) will trigger the execution of the associated subsection, as the-best
+# practices are written wholly independent of each other.
 rhel9cis_syslog: rsyslog
+## Control 4.2.1.5 | PATCH | Ensure logging is configured
+# This variable governs if current Ansible role should manage syslog settings
+# in /etc/rsyslog.conf file, namely mail, news and misc(warn, messages)
 rhel9cis_rsyslog_ansiblemanaged: true
 
-#### 4.2.1.6 remote and destation log server name
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable governs if 'rsyslog' service should be automatically configured to forward messages to a
+# remote log server. If set to 'false', the configuration of the 'omfwd' plugin, used to provide forwarding
+# over UDP or TCP, will not be performed.
 rhel9cis_remote_log_server: false
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the value of the 'target' parameter to be configured when enabling
+# forwarding syslog messages to a remote log server, thus configuring the actual FQDN/IP address of the
+# destination server. For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_host: logagg.example.com
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the value of the 'port' parameter to be configured when enabling
+# forwarding syslog messages to a remote log server. The default value for this destination port is 514.
+# For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_port: 514
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the value("TCP"/"UDP") of the 'protocol' parameter to be configured when enabling
+# forwarding syslog messages to a remote log server. The default value for the 'omfwd' plug-in is UDP.
+# For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_protocol: tcp
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable governs how often an action is retried(value is passed to 'action.resumeRetryCount' parameter) before
+# it is considered to have failed(that roughly translates to discarded messages). The default value is 0, but
+# when set to "-1"(eternal), this setting would prevent rsyslog from dropping messages when retrying to connect
+# if server is not responding. For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_retrycount: 100
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the maximum number of messages that can be hold(value is passed to 'queue.size' parameter).
+# For this value to be reflected in the configuration, the variable which enables the automatic configuration
+# of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_queuesize: 1000
 
-#### 4.2.1.7
+## Control 4.2.1.7 - Ensure rsyslog is not configured to receive logs from a remote client
+# This variable expresses whether the system is used as a log server or not. If set to:
+#  - 'false', current system will act as a log CLIENT, thus it should NOT receive data from other hosts.
+#  - 'true', current system will act as a log SERVER, enabling centralised log management(by protecting log integrity
+# from local attacks on remote clients)
 rhel9cis_system_is_log_server: false
 
-# 4.2.2.1.2
-# rhel9cis_journal_upload_url is the ip address to upload the journal entries to
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# 'rhel9cis_journal_upload_url' is the ip address to upload the journal entries to
+#  URL value may specify either just the hostname or both the protocol and hostname. 'https' is the default. The port
+#  number may be specified after a colon (":"), otherwise 19532 will be used by default.
 rhel9cis_journal_upload_url: 192.168.50.42
-# The paths below have the default paths/files, but allow user to create custom paths/filenames
-rhel9cis_journal_upload_serverkeyfile: "/etc/ssl/private/journal-upload.pem"
-rhel9cis_journal_servercertificatefile: "/etc/ssl/certs/journal-upload.pem"
-rhel9cis_journal_trustedcertificatefile: "/etc/ssl/ca/trusted.pem"
+## The paths below have the default paths/files, but allow user to create custom paths/filenames
 
-# 4.2.2.1
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# This variable specifies the path to the private key file used by the remote journal
+# server to authenticate itself to the client. This key is used alongside the server's
+# public certificate to establish secure communication.
+rhel9cis_journal_upload_serverkeyfile: "/etc/ssl/private/journal-upload.pem"
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# This variable specifies the path to the public certificate file of the remote journal
+# server. This certificate is used to verify the authenticity of the remote server.
+rhel9cis_journal_servercertificatefile: "/etc/ssl/certs/journal-upload.pem"
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# This variable specifies the path to a file containing one or more public certificates
+# of certificate authorities (CAs) that the client trusts. These trusted certificates are used
+# to validate the authenticity of the remote server's certificate.
+rhel9cis_journal_trustedcertificatefile: "/etc/ssl/ca/trusted.pem"
+# ATTENTION: Uncomment the keyword below when values are set!
+
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# Current variable configures the max amount of disk space the logs will use(thus, journal files
+# will not grow without bounds)
 # The variables below related to journald, please set these to your site specific values
-# rhel9cis_journald_systemmaxuse is the max amount of disk space the logs will use
+# These variable specifies how much disk space the journal may use up at most
+# Specify values in bytes or use K, M, G, T, P, E as units for the specified sizes.
+# See https://www.freedesktop.org/software/systemd/man/journald.conf.html for more information.
 rhel9cis_journald_systemmaxuse: 10M
-# rhel9cis_journald_systemkeepfree is the amount of disk space to keep free
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# Current variable configures the amount of disk space to keep free for other uses.
 rhel9cis_journald_systemkeepfree: 100G
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# This variable configures how much disk space the journal may use up at most.
+# Similar with 'rhel9cis_journald_systemmaxuse', but related to runtime space.
 rhel9cis_journald_runtimemaxuse: 10M
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# This variable configures the actual amount of disk space to keep free
+# Similar with 'rhel9cis_journald_systemkeepfree', but related to runtime space.
 rhel9cis_journald_runtimekeepfree: 100G
-# rhel9cis_journald_MaxFileSec is how long in time to keep log files. Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# Current variable governs the settings for log retention(how long the log files will be kept).
+# Thus, it specifies the maximum time to store entries in a single journal
+# file before rotating to the next one. Set to 0 to turn off this feature.
+# The given values is interpreted as seconds, unless suffixed with the units
+# `year`, `month`, `week`, `day`, `h` or `m` to override the default time unit of seconds.
+# Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
+# ATTENTION: Uncomment the keyword below when values are set!
 rhel9cis_journald_maxfilesec: 1month
 
-#### 4.3
+## Control 4.3 - Ensure logrotate is configured
+# This variable defines the log file rotation period.
+# Options are: daily, weekly, monthly, yearly.
 rhel9cis_logrotate: "daily"
 
 ## Section5 vars
 
-# This will allow use of drop in files when CIS adopts them.
+## Section 5.2 - SSH
+
+# This value, containing the absolute filepath of the produced 'sshd' config file, allows usage of
+# drop-in files('/etc/ssh/ssh_config.d/{ssh_drop_in_name}.conf', supported by RHEL9) when CIS adopts them.
+# Otherwise, the default value is '/etc/ssh/ssh_config'.
 rhel9_cis_sshd_config_file: /etc/ssh/sshd_config
 
+## Controls:
+## - 5.2.4  - Ensure SSH access is limited
+## - 5.2.19 - Ensure SSH LoginGraceTime is set to one minute or less
+## - 5.2.20 - Ensure SSH Idle Timeout Interval is configured
 rhel9cis_sshd:
+    # This variable sets the maximum number of unresponsive "keep-alive" messages
+    # that can be sent from the server to the client before the connection is considered
+    # inactive and thus, closed.
     clientalivecountmax: 0
+    # This variable sets the time interval in seconds between sending "keep-alive"
+    # messages from the server to the client. These types of messages are intended to
+    # keep the connection alive and prevent it being terminated due to inactivity.
     clientaliveinterval: 900
+    # This variable specifies the amount of seconds allowed for successful authentication to
+    # the SSH server.
     logingracetime: 60
-    # WARNING: make sure you understand the precedence when working with these values!!
-    # allowusers:
-    # allowgroups: systems dba
-    # denyusers:
-    # denygroups:
+    # This variable, if specified, configures a list of USER name patterns, separated by spaces, to allow SSH
+    # access for users whose user name matches one of the patterns. This is done
+    # by setting the value of `AllowUsers` option in `/etc/ssh/sshd_config` file.
+    # If an USER@HOST format will be used, the specified user will be allowed only on that particular host.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, see https://linux.die.net/man/5/sshd_config
+    allow_users: ""
+    # (String) This variable, if spcieifed, configures a list of GROUP name patterns, separated by spaces, to allow SSH access
+    # for users whose primary group or supplementary group list matches one of the patterns. This is done
+    # by setting the value of `AllowGroups` option in `/etc/ssh/sshd_config` file.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, https://linux.die.net/man/5/sshd_config
+    allow_groups: "wheel"
+    # This variable, if specified, configures a list of USER name patterns, separated by spaces, to prevent SSH access
+    # for users whose user name matches one of the patterns. This is done
+    # by setting the value of `DenyUsers` option in `/etc/ssh/sshd_config` file.
+    # If an USER@HOST format will be used, the specified user will be restricted only on that particular host.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, see https://linux.die.net/man/5/sshd_config
+    deny_users: "nobody"
+    # This variable, if specified, configures a list of GROUP name patterns, separated by spaces, to prevent SSH access
+    # for users whose primary group or supplementary group list matches one of the patterns. This is done
+    # by setting the value of `DenyGroups` option in `/etc/ssh/sshd_config` file.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, see https://linux.die.net/man/5/sshd_config
+    deny_groups: ""
 
-# 5.2.5 SSH LogLevel setting. Options are INFO or VERBOSE
+## Control 5.2.5 - Ensure SSH LogLevel is appropriate
+# This variable is used to control the verbosity of the logging produced by the SSH server.
+# The options for setting it are as follows:
+# - `QUIET`: Minimal logging;
+# - `FATAL`: logs only fatal errors;
+# - `ERROR`: logs error messages;
+# - `INFO`: logs informational messages in addition to errors;
+# - `VERBOSE`: logs a higher level of detail, including login attempts and key exchanges;
+# - `DEBUG`: generates very detailed debugging information including sensitive information.
+# - `DEBUG(x)`: Whereas x = debug level 1 to 3, DEBUG=DEBUG1.
 rhel9cis_ssh_loglevel: INFO
 
-# 5.2.19 SSH MaxSessions setting. Must be 4 our less
+## Control 5.2.18 - Ensure SSH MaxSessions is set to 10 or less
+# This variable value specifies the maximum number of open sessions that are permitted from
+# a given location
 rhel9cis_ssh_maxsessions: 4
-rhel9cis_inactivelock:
-    lock_days: 30
 
+## Control 5.6.1.4 - Ensure inactive password lock is 30 days or less
+rhel9cis_inactivelock:
+    # This variable specifies the number of days of inactivity before an account will be locked.
+    # CIS requires a value of 30 days or less.
+    lock_days: 30
+# This variable governs if authconfig package should be installed. This package provides a simple method of
+# configuring /etc/sysconfig/network to handle NIS, as well as /etc/passwd and /etc/shadow, the files used
+# for shadow password support. Basic LDAP, Kerberos 5, and Winbind client configuration is also provided.
 rhel9cis_use_authconfig: false
-# 5.3.1/5.3.2 Custom authselect profile settings. Settings in place now will fail, they are place holders from the control example
-# Due to the way many multiple options and ways to configure this control needs to be enabled and settings adjusted to minimise risk
+
+## Section 5.4 - Configure authselect: Custom authselect profile settings(name, profile to customize, options)
+## Controls:
+#  - 5.4.1 - Ensure custom authselect profile is used('custom_profile_name', 'default_file_to_copy' subsettings)
+#  - 5.4.2 - Ensure authselect includes with-faillock | with auth select profile('custom_profile_name')
+# Settings in place now will fail, they are placeholders from the control example. Due to the way many multiple
+# options and ways to configure this control needs to be enabled and settings adjusted to minimise risk.
 rhel9cis_authselect:
+    # This variable configures the name of the custom profile to be created and selected.
     custom_profile_name: custom-profile
+    # This variable configures the ID of the existing profile that should be used as a base for the new profile.
     default_file_to_copy: "sssd --symlink-meta"
     options: with-sudo with-faillock without-nullok
 
-# 5.3.1 Enable automation to create custom profile settings, using the settings above
+## Control 5.4.1 - Ensure custom authselect profile is used
+# This variable governs if an authselect custom profile should be automatically created, by copying and
+# customizing one of the default profiles. The default profiles include: sssd, winbind, or the nis. This profile can then be
+# customized to follow site specific requirements.
 rhel9cis_authselect_custom_profile_create: false
 
-# 5.3.2 Enable automation to select custom profile options, using the settings above
+## Control 5.4.2 - Ensure authselect includes with-faillock | Create custom profiles
+# This variable governs if the existing custom profile should be selected(Note: please keep in mind that all future updates
+# to the PAM templates and meta files in the original profile will be reflected in your custom profile, too.)
 rhel9cis_authselect_custom_profile_select: false
 
+## Section 5.6.1.x: Shadow Password Suite Parameters
 rhel9cis_pass:
+    ## Control 5.6.1.1 - Ensure password expiration is 365 days or less
+    # This variable governs after how many days a password expires.
+    # CIS requires a value of 365 or less.
     max_days: 365
+    ## Control 5.6.1.2 - Ensure minimum days between password changes is 7 or more
+    # This variable specifies the minimum number of days allowed between changing
+    # passwords. CIS requires a value of at least 1.
     min_days: 7
+    ## Control 5.6.1.3 - Ensure password expiration warning days is 7 or more
+    # This variable governs, how many days before a password expires, the user will be warned.
+    # CIS requires a value of at least 7.
     warn_age: 7
 
-# 5.5.1
-## PAM
+## Control 5.5.1 - Ensure password creation requirements are configured  - PAM
 rhel9cis_pam_password:
+    # This variable sets the minimum chars a password needs to be set.
     minlen: 14
+    # This variable set password complexity,the minimum number of
+    # character types that must be used (i.e., uppercase, lowercase, digits, other)
+    # Set to 2, passwords cannot have all lower/upper case.
+    # Set to 3, passwords needs numbers.
+    # set to 4, passwords will have to include all four types of characters.
     minclass: 4
 
+## Controls
+# - 5.5.2 - Ensure lockout for failed password attempts is configured
+# - 5.5.3 - Ensure password reuse is limited
+# - 5.5.4 - Ensure password hashing algorithm is SHA-512
+# - 5.4.2 -  Ensure authselect includes with-faillock
 rhel9cis_pam_faillock:
+    # This variable sets the amount of time a user will be unlocked after the max amount of
+    #   password failures.
     unlock_time: 900
+    # This variable sets the amount of tries a password can be entered, before a user is locked.
     deny: 5
+    # This variable represents the number of password change cycles, after which
+    # an user can re-use a password.
+    # CIS requires a value of 5 or more.
     remember: 5
 
 # UID settings for interactive users
 # These are discovered via logins.def if set true
 discover_int_uid: false
+### Controls:
+# - 5.6.2 -  Ensure system accounts are secured
+# - 6.2.10 - Ensure local interactive user home directories exist
+# - 6.2.11 - Ensure local interactive users own their home directories
+# This variable sets the minimum number from which to search for UID
+# Note that the value will be dynamically overwritten if variable `dicover_int_uid` has
+# been set to `true`.
 min_int_uid: 1000
+### Controls:
+# - 6.2.10 - Ensure local interactive user home directories exist
+# - 6.2.11 - Ensure local interactive users own their home directories
+# This variable sets the maximum number at which the search stops for UID
+# Note that the value will be dynamically overwritten if variable `dicover_int_uid` has
+# been set to `true`.
 max_int_uid: 65533
 
-# 5.3.3 var log location variable
+## Control 5.3.3 - Ensure sudo log file exists
+# By default, sudo logs through syslog(3). However, to specify a custom log file, the
+# 'logfile' parameter will be used, setting it with current variable's value.
+# This variable defines the path and file name of the sudo log file.
 rhel9cis_sudolog_location: "/var/log/sudo.log"
 
-#### 5.3.6
+## Control 5.3.6 -Ensure sudo authentication timeout is configured correctly
+# This variable sets the duration (in minutes) during which a user's authentication credentials
+# are cached after successfully authenticating using "sudo". This allows the user to execute
+# multiple commands with elevated privileges without needing to re-enter their password for each
+# command within the specified time period. CIS requires a value of at most 15 minutes.
 rhel9cis_sudo_timestamp_timeout: 15
 
-### 5.4.2 authselect and faillock
+## Control 5.4.2 - authselect and faillock
 ## This option is used at your own risk it will enable faillock for users
 ## Only to be used on a new clean system if not using authselect
-## THIS CAN BREAK ACCESS EVEN FOR ROOT - UNDERSTAND RISKS ##
+## THIS CAN BREAK ACCESS EVEN FOR ROOT - PLEASE UNDERSTAND RISKS !
 rhel9cis_add_faillock_without_authselect: false
-# This needs to be set to ACCEPT
+# This needs to be set to 'ACCEPT'(as string), besides setting 'rhel9cis_add_faillock_without_authselect'
+# to 'true', in order to include the 'with-failock' option to the current authselect profile.
 rhel9cis_5_4_2_risks: NEVER
 
-# RHEL-09-5.4.5
+## Control 5.6.3 - Ensure default user shell timeout is 900 seconds or less
 # Session timeout setting file (TMOUT setting can be set in multiple files)
 # Timeout value is in seconds. (60 seconds * 10 = 600)
 rhel9cis_shell_session_timeout:
+    # This variable specifies the path of the timeout setting file.
+    # (TMOUT setting can be set in multiple files, but only one is required for the
+    # rule to pass. Options are:
+    # - a file in `/etc/profile.d/` ending in `.s`,
+    # - `/etc/profile`, or
+    # - `/etc/bash.bashrc`.
     file: /etc/profile.d/tmout.sh
+    # This variable represents the amount of seconds a command or process is allowed to
+    # run before being forcefully terminated.
+    # CIS requires a value of at most 900 seconds.
     timeout: 600
-# RHEL-09-5.4.1.5 Allow ansible to expire password for account with a last changed date in the future. False will just display users in violation, true will expire those users passwords
+
+## Control 5.6.1.5 - Ensure all users last password change date is in the past
+# Allow ansible to expire password for account with a last changed date in the future. Setting it
+# to 'false' will just display users in violation, while 'true' will expire those users passwords.
 rhel9cis_futurepwchgdate_autofix: true
 
-# 5.3.7
+## Control 5.3.7 - Ensure access to the 'su' command is restricted
+# This variable determines the name of the group of users that are allowed to use the su command.
+# CIS requires that such a group be CREATED(named according to site policy) and be kept EMPTY.
 rhel9cis_sugroup: nosugroup
 
 ## Section6 vars
 
-# RHEL-09_6.1.1
+## Control 6.1.15 - Audit system file permissions | Create list and warning
+# The RPM package-manager has many useful options. For example, using option:
+#  - '-V': RPM can automatically check if system packages are correctly installed
+#  - '-qf': RPM can be used to determine which package a particular file belongs to
+# Auditing system file-permissions takes advantage of the combination of those two options and, therefore, is able to
+# detect any discrepancy regarding installed packages, redirecting the output of this combined
+# command into a specific file. If no output is returned, the package is installed correctly.
+# Current variable stores the preferred absolute filepath for such a file, therefore if this file
+# contains any lines, an alert message will be generated to warn about each discrepancy.
 rhel9cis_rpm_audit_file: /var/tmp/rpm_file_check
 
-# RHEL-09_6.1.10 Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable
+## Control 6.1.9 - Ensure no world writable files exist
+# Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable.
 rhel9cis_no_world_write_adjust: true
+
 rhel9cis_passwd_label: "{{ (this_item | default(item)).id }}: {{ (this_item | default(item)).dir }}"
 
-# 6.2.16
-## Dont follow symlinks for changes to user home directory thanks to @dulin-gnet and comminty for rhel8-cis reedbacj
+## Control 6.2.16 - Ensure local interactive user dot files are not group or world writable
+# This boolean variable governs if current role should follow filesystem links for changes to
+# user home directory.
 rhel_09_6_2_16_home_follow_symlinks: false
+# thanks to @dulin-gnet and community for rhel8-cis feedback.
 
 #### Goss Configuration Settings ####
 # Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1028,7 +1028,7 @@ rhel9cis_sshd:
     # This variable sets the time interval in seconds between sending "keep-alive"
     # messages from the server to the client. These types of messages are intended to
     # keep the connection alive and prevent it being terminated due to inactivity.
-    clientaliveinterval: 900
+    clientaliveinterval: 15
     # This variable specifies the amount of seconds allowed for successful authentication to
     # the SSH server.
     logingracetime: 60

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,19 @@
 ---
 # defaults file for rhel9-cis
+# WARNING:
+# These values may be overriden by other vars-setting options(e.g. like the below 'container_vars_file'), as explained here:
+# https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable
 
+## Usage on containerized images
+# The role discovers dynamically (in tasks/main.yml) whether it
+# is executed on a container image and sets the variable
+# system_is_container the true. Otherwise, the default value
+# 'false' is left unchanged.
 system_is_container: false
+# The filename of the existing yml file in role's  'vars/' sub-directory
+# to be used for managing the role-behavior when a container was detected:
+# (de)activating rules or for other tasks(e.g. disabling Selinux or a specific
+# firewall-type).
 container_vars_file: is_container.yml
 # rhel9cis is left off the front of this var for consistency in testing pipeline
 # system_is_ec2 toggle will disable tasks that fail on Amazon EC2 instances. Set true to skip and false to run tasks
@@ -11,6 +23,10 @@ system_is_ec2: false
 # Supported OSs will not need for this to be changed - see README e.g. CentOS
 os_check: true
 
+## Switching on/off specific baseline sections
+# These variables govern whether the tasks of a particular section are to be executed when running the role.
+# E.g: If you want to execute the tasks of Section 1 you should set the "_section1" variable to true.
+# If you do not want the tasks from that section to get executed you simply set the variable to "false".
 rhel9cis_section1: true
 rhel9cis_section2: true
 rhel9cis_section3: true
@@ -25,7 +41,12 @@ rhel9cis_section6: true
 rhel9cis_level_1: true
 rhel9cis_level_2: true
 
+## Section 1.6 - Mandatory Access Control
+# This variable governs whether SELinux is disabled or not. If SELinux is NOT DISABLED by setting
+# 'rhel9cis_selinux_disable' to 'true', the 1.6 subsection will be executed.
 rhel9cis_selinux_disable: false
+# This variable is used in a preliminary task, handling grub2 paths either in case of
+# UEFI boot('/etc/grub2-efi.cfg') or in case of BIOS legacy-boot('/etc/grub2.cfg').
 rhel9cis_legacy_boot: false
 
 ## Python Binary
@@ -39,7 +60,8 @@ benchmark_version: 'v1.0.0'
 
 benchmark: RHEL9-CIS
 
-# Whether to skip the reboot
+# Whether to skip the system reboot before audit
+# System will reboot if false, can give better audit results
 skip_reboot: true
 
 # default value will change to true but wont reboot if not enabled but will error
@@ -48,44 +70,66 @@ change_requires_reboot: false
 ##########################################
 ### Goss is required on the remote host ###
 ## Refer to vars/auditd.yml for any other settings ##
+#### Basic external goss audit enablement settings ####
+#### Precise details - per setting can be found at the bottom of this file ####
 
-# Allow audit to setup the requirements including installing git (if option chosen and downloading and adding goss binary to system)
+
+## Audit setup
+# Audits are carried out using Goss. This variable
+# determines whether execution of the role prepares for auditing
+# by installing the required binary.
 setup_audit: false
 
-# enable audits to run - this runs the audit and get the latest content
+## Enable audits to run - this runs the audit and get the latest content
+# This variable governs whether the audit using the
+# separately maintained audit role using Goss
+# is carried out.
 run_audit: false
 
 # Only run Audit do not remediate
 audit_only: false
-# As part of audit_only
-# This will enable files to be copied back to control node
+# This will enable files to be copied back to control node(part of audit_only)
 fetch_audit_files: false
-# Path to copy the files to will create dir structure
+# Path to copy the files to will create dir structure(part of audit_only)
 audit_capture_files_dir: /some/location to copy to on control node
 
-# How to retrieve audit binary
-# Options are copy or download - detailed settings at the bottom of this file
-# you will need to access to either github or the file already dowmloaded
+## How to retrieve audit binary(Goss)
+# Options are 'copy' or 'download' - detailed settings at the bottom of this file
+# - if 'copy':
+#    - the filepath mentioned via the below 'audit_bin_copy_location' var will be used to access already downloaded Goss
+# - if 'download':
+#    - the GitHub Goss-releases URL will be used for a fresh-download, via 'audit_bin_url' and 'audit_pkg_arch_name' vars
 get_audit_binary_method: download
 
-## if get_audit_binary_method - copy the following needs to be updated for your environment
+## if get_audit_binary_method is 'copy', the following var needs to be updated for your environment
 ## it is expected that it will be copied from somewhere accessible to the control node
 ## e.g copy from ansible control node to remote host
 audit_bin_copy_location: /some/accessible/path
 
-# how to get audit files onto host options
+## How to retrieve the audit role
+# The role for auditing is maintained separately.
+# This variable specifies the method of how to get the audit role
 # options are git/copy/get_url other e.g. if you wish to run from already downloaded conf
+# onto the system. The options are as follows:
+# - 'git': clone audit content from GitHub REPOSITORY, set up via `audit_file_git` var, and
+#          VERSION(e.g. branch, tag name), set up via `audit_git_version` var.
+# - 'copy': copy from path as specified in variable `audit_conf_copy`.
+# - 'archive': same as 'copy', only that the specified filepath needs to be unpacked.
+# - 'get_url': Download from url as specified in variable `audit_files_url`
 audit_content: git
 
-# archive or copy:
+# This variable(only used when 'audit_content' is 'copy' or 'archive') should
+# contain the filepath with audit-content to be copied/unarchived on server:
 audit_conf_copy: "some path to copy from"
 
-# get_url:
+# This variable(only used when 'audit_content' is 'get_url') should
+# contain the URL from where the audit-content must be downloaded on server:
 audit_files_url: "some url maybe s3?"
 
 # Run heavy tests - some tests can have more impact on a system enabling these can have greater impact on a system
 audit_run_heavy_tests: true
 
+# Timeout for those cmds that take longer to run where timeout set
 # This variable specifies the timeout (in ms) for audit commands that
 # take a very long time: if a command takes too long to complete,
 # it will be forcefully terminated after the specified duration.
@@ -97,7 +141,9 @@ audit_cmd_timeout: 120000
 # the CIS benchmark documents.
 # PLEASE NOTE: These work in coordination with the section # group variables and tags.
 # You must enable an entire section in order for the variables below to take effect.
-# Section 1 rules
+
+# Section 1 is Initial setup (FileSystem Configuration, Configure Software Updates, Filesystem Integrity Checking, Secure Boot Settings,
+# Additional Process Hardening, Mandatory Access Control, Command Line Warning Banners, and GNOME Display Manager)
 rhel9cis_rule_1_1_1_1: true
 rhel9cis_rule_1_1_1_2: true
 rhel9cis_rule_1_1_2_1: true
@@ -170,7 +216,7 @@ rhel9cis_rule_1_8_10: true
 rhel9cis_rule_1_9: true
 rhel9cis_rule_1_10: true
 
-# Section 2 rules
+# Section 2 rules are controling Services (Special Purpose Services, and service clients)
 rhel9cis_rule_2_1_1: true
 rhel9cis_rule_2_1_2: true
 rhel9cis_rule_2_2_1: true
@@ -197,7 +243,7 @@ rhel9cis_rule_2_3_3: true
 rhel9cis_rule_2_3_4: true
 rhel9cis_rule_2_4: true
 
-# Section 3 rules
+# Section 3 rules are used for securely configuring the network configuration(kernel params, ACL, Firewall settings)
 rhel9cis_rule_3_1_1: true
 rhel9cis_rule_3_1_2: true
 rhel9cis_rule_3_1_3: true
@@ -222,7 +268,8 @@ rhel9cis_rule_3_4_2_5: true
 rhel9cis_rule_3_4_2_6: true
 rhel9cis_rule_3_4_2_7: true
 
-# Section 4 rules
+# Section 4 rules are Logging and Auditing (Configure System Accounting (auditd),
+# Configure Data Retention, and Configure Logging)
 rhel9cis_rule_4_1_1_1: true
 rhel9cis_rule_4_1_1_2: true
 rhel9cis_rule_4_1_1_3: true
@@ -281,7 +328,8 @@ rhel9cis_rule_4_2_2_7: true
 rhel9cis_rule_4_2_3: true
 rhel9cis_rule_4_3: true
 
-# Section 5 rules
+# Section 5 rules control Access, Authentication, and Authorization (Configure time-based job schedulers,
+# Configure sudo, Configure SSH Server, Configure PAM and User Accounts and Environment)
 rhel9cis_rule_5_1_1: true
 rhel9cis_rule_5_1_2: true
 rhel9cis_rule_5_1_3: true
@@ -336,7 +384,7 @@ rhel9cis_rule_5_6_4: true
 rhel9cis_rule_5_6_5: true
 rhel9cis_rule_5_6_6: true
 
-# Section 6 rules
+# Section 6 rules controls System Maintenance (System File Permissions and User and Group Settings)
 rhel9cis_rule_6_1_1: true
 rhel9cis_rule_6_1_2: true
 rhel9cis_rule_6_1_3: true
@@ -371,140 +419,371 @@ rhel9cis_rule_6_2_16: true
 
 ## Section 1 vars
 
-#### 1.1.2
-# These settings go into the /etc/fstab file for the /tmp mount settings
-# The value must contain nosuid,nodev,noexec to conform to CIS standards
-# rhel9cis_tmp_tmpfs_settings: "defaults,rw,nosuid,nodev,noexec,relatime 0 0"
-# If set true uses the tmp.mount service else using fstab configuration
+## Control 1.1.2
+# If set to `true`, rule will be implemented using the `tmp.mount` systemd-service,
+# otherwise fstab configuration will be used.
+# These /tmp settings will include nosuid,nodev,noexec to conform to CIS standards.
 rhel9cis_tmp_svc: false
 
-#### 1.1.9
+## Control 1.1.9
 rhel9cis_allow_autofs: false
 
-# 1.2.1
+## Control 1.2.1
 # This is the login information for your RedHat Subscription
 # DO NOT USE PLAIN TEXT PASSWORDS!!!!!
 # The intent here is to use a password utility like Ansible Vault here
 rhel9cis_rh_sub_user: user
 rhel9cis_rh_sub_password: password  # pragma: allowlist secret
 
-# 1.2.2
+## Control 1.2.2
 # Do you require rhnsd
 # RedHat Satellite Subscription items
 rhel9cis_rhnsd_required: false
 
-# 1.2.4 repo_gpgcheck
+## Control 1.2.4
+# When installing RHEL from authorized Red Hat source, RHEL will come with default YUM repository. NOT having a default YUM
+# repo ('rhel9cis_rhel_default_repo' set as 'false'), in conjunction with 'rhel9cis_rule_enable_repogpg' set as 'True', will enable the tasks
+# which check the GPG signatures for all the individual YUM repositories.
 rhel9cis_rhel_default_repo: true
+## Control 1.2.4
+# When 'rhel9cis_rule_enable_repogpg' is set to 'true'(in conjunction with 'rhel9cis_rhel_default_repo':'false'), conditions are met for
+# enabling the GPG signatures-check for all the individual YUM repositories. If GPG signatures-check is enabled on repositories which do not
+# support it(like RedHat), installation of packages will fail.
 rhel9cis_rule_enable_repogpg: true
 
-# 1.4.1 Bootloader password
+## Control 1.4.1
+# This variable will store the hashed GRUB bootloader password to be stored in '/boot/grub2/user.cfg' file. The default value
+# must be changed to a value that may be generated with this command 'grub2-mkpasswd-pbkdf2' and must comply with
+# this format: 'grub.pbkdf2.sha512.<Rounds>.<Salt>.<Checksum>'
 rhel9cis_bootloader_password_hash: 'grub.pbkdf2.sha512.10000.9306A36764A7BEA3BF492D1784396B27F52A71812E9955A58709F94EE70697F9BD5366F36E07DEC41B52279A056E2862A93E42069D7BBB08F5DFC2679CD43812.6C32ADA5449303AD5E67A4C150558592A05381331DE6B33463469A236871FA8E70738C6F9066091D877EF88A213C86825E093117F30E9E1BF158D0DB75E7581B'  # pragma: allowlist secret
 rhel9cis_bootloader_password: random  # pragma: allowlist secret
+## Control 1.4.1
+# This variable governs whether a bootloader password should be set in '/boot/grub2/user.cfg' file.
 rhel9cis_set_boot_pass: true
 
-# 1.8 Gnome Desktop
+## Control 1.8.x - Settings for GDM
+# This variable specifies the GNOME configuration database file to which configurations are written.
+# (See "https://help.gnome.org/admin/system-admin-guide/stable/dconf-keyfiles.html.en")
+# The default database is 'local'.
 rhel9cis_dconf_db_name: local
-rhel9cis_screensaver_idle_delay: 900  # Set max value for idle-delay in seconds (between 1 and 900)
-rhel9cis_screensaver_lock_delay: 5  # Set max value for lock-delay in seconds (between 0 and 5)
+# This variable governs the number of seconds of inactivity before the screen goes blank.
+# Set max value for idle-delay in seconds (between 1 and 900)
+rhel9cis_screensaver_idle_delay: 900
+# This variable governs the number of seconds the screen remains blank before it is locked.
+# Set max value for lock-delay in seconds (between 0 and 5)
+rhel9cis_screensaver_lock_delay: 5
 
-# 1.10/1.11 Set crypto policy (LEGACY, DEFAULT, FUTURE, FIPS)
-# Control 1.10 states do not use LEGACY and control 1.11 says to use FUTURE or FIPS.
+## Control 1.10
+# This variable contains the value to be set as the system-wide crypto policy. Current rule enforces NOT USING
+# 'LEGACY' value(as it is less secure, it just ensures compatibility with legacy systems), therefore
+# possible values for this variable are, as explained by RedHat docs:
+#  -'DEFAULT': reasonable default policy for today's standards (balances usability and security)
+#  -'FUTURE': conservative security level that is believed to withstand any near-term future attacks
+#  -'FIPS': A level that conforms to the FIPS140-2 requirements
 rhel9cis_crypto_policy: 'DEFAULT'
-# Added module to be allowed as default setting (Allowed options in vars/main.yml)
+## Control 1.10
+# This variable contains the value of the crypto policy module(combinations of policies and
+# sub-policies) to be allowed as default setting. Allowed options are defined in 'vars/main.yml' file,
+# using 'rhel9cis_allowed_crypto_policies_modules' variable.
 rhel9cis_crypto_policy_module: ''
 
 # System network parameters (host only OR host and router)
+# This variable governs whether specific CIS rules
+# concerned with acceptance and routing of packages are skipped.
 rhel9cis_is_router: false
 
-# IPv6 required
+## IPv6 requirement toggle
+# This variable governs whether ipv6 is enabled or disabled.
 rhel9cis_ipv6_required: true
 
-# AIDE
+## Control 1.3.1 - allow aide to be configured
+# AIDE is a file integrity checking tool, similar in nature to Tripwire.
+# While it cannot prevent intrusions, it can detect unauthorized changes
+# to configuration files by alerting when the files are changed. Review
+# the AIDE quick start guide and AIDE documentation before proceeding.
+# By setting this variable to `true`, all of the settings related to AIDE will be applied!
 rhel9cis_config_aide: true
-# AIDE cron settings
+
+## Control 1.3.2 AIDE cron settings
+# These are the crontab settings for periodical checking of the filesystem's integrity using AIDE.
+# The sub-settings of this variable provide the parameters required to configure
+# the cron job on the target system.
+# Cron is a time-based job scheduling program in Unix OS, which allows tasks to be scheduled
+# and executed automatically at a certain point in time.
 rhel9cis_aide_cron:
+    # This variable represents the user account under which the cron job for AIDE will run.
     cron_user: root
+    # This variable represents the path to the AIDE crontab file.
     cron_file: /etc/cron.d/aide_cron
+    # This variable represents the actual command or script that the cron job
+    # will execute for running AIDE.
     aide_job: '/usr/sbin/aide --check'
+    # These variables define the schedule for the cron job
+    # This variable governs the minute of the time of day when the AIDE cronjob is run.
+    # It must be in the range `0-59`.
     aide_minute: 0
+    # This variable governs the hour of the time of day when the AIDE cronjob is run.
+    # It must be in the range `0-23`.
     aide_hour: 5
+    # This variable governs the day of the month when the AIDE cronjob is run.
+    # `*` signifies that the job is run on all days; furthermore, specific days
+    # can be given in the range `1-31`; several days can be concatenated with a comma.
+    # The specified day(s) can must be in the range  `1-31`.
     aide_day: '*'
+    # This variable governs months when the AIDE cronjob is run.
+    # `*` signifies that the job is run in every month; furthermore, specific months
+    # can be given in the range `1-12`; several months can be concatenated with commas.
+    # The specified month(s) can must be in the range  `1-12`.
     aide_month: '*'
+    # This variable governs the weekdays, when the AIDE cronjob is run.
+    # `*` signifies that the job is run on all weekdays; furthermore, specific weekdays
+    # can be given in the range `0-7` (both `0` and `7` represent Sunday); several weekdays
+    # can be concatenated with commas.
     aide_weekday: '*'
 
-# SELinux policy
+## Control 1.6.1.3|4|5 - SELinux policy settings
+# This selects type of policy; targeted or mls( multilevel )
+# mls should not be used, since it will disable unconfined policy module
+# and may prevent some services from running. Requires SELinux not being disabled (by
+# having 'rhel9cis_selinux_disable' var set as 'true'), otherwise setting will be ignored.
 rhel9cis_selinux_pol: targeted
-# chose onf or enfocing or permissive
+## Control 1.6.1.3|4 - SELinux configured and not disabled
+# This variable contains a specific SELinux mode, respectively:
+#  - 'enforcing':  SELinux policy IS enforced, therefore denies operations based on SELinux policy
+# rules. If system was installed with SELinux, this is enabled by default.
+#  - 'permissive': SELinux policy IS NOT enforced, therefore does NOT deny any operation, only
+# logs AVC(Access Vector Cache) messages. RedHat docs suggest it "can be used
+# briefly to check if SELinux is the culprit in preventing your application
+# from working".
+# CIS expects enforcing since permissive allows operations that might compromise the system.
+# Even though logging still occurs.
 rhel9cis_selinux_enforce: enforcing
 
 # Whether or not to run tasks related to auditing/patching the desktop environment
 
-## 2. Services
+## Section 2. Services
 
 ### 2.1 Time Synchronization
-#### 2.1.2 Time Synchronization servers - used in template file chrony.conf.j2
+
+
+## Control 2.1.2 Time Synchronization servers - used in template file chrony.conf.j2
+# The following variable represents a list of time servers used
+# for configuring chrony, timesyncd, and ntp.
+# Each list item contains two settings, `name` (the domain name of the server) and synchronization `options`.
+# The default setting for the `options` is `minpoll` but `iburst` can be used, please refer to the documentation
+# of the time synchronization mechanism you are using.
 rhel9cis_time_synchronization_servers:
     - 0.pool.ntp.org
     - 1.pool.ntp.org
     - 2.pool.ntp.org
     - 3.pool.ntp.org
+## Control 2.1.2 - Time Synchronization servers
+# This variable should contain the default options to be used for every NTP server hostname defined
+# within the 'rhel9cis_time_synchronization_servers' var.
 rhel9cis_chrony_server_options: "minpoll 8"
+# This variable, if set to 'true'(default), will inform the kernel the system clock is kept synchronized
+# and the kernel will update the real-time clock every 11 minutes. Otherwise, if 'rtcsync' option is
+# disabled, chronyd will not be in sync(kernel discipline is disabled, 11 minutes mode will be off).
 rhel9cis_chrony_server_rtcsync: false
+# This variable configures the values to be used by chronyd to gradually correct any time offset,
+# by slowing down/speeding up the clock. An example of this directive usage would be:
+# 'makestep 1000 10'.
+# Step the system clock:
+#   - IF the adjustment is larger than 1000 seconds
+#   - but ONLY IN the first ten clock updates
 rhel9cis_chrony_server_makestep: "1.0 3"
+# This variable configures the minimum number of sources that need to be considered as selectable in the source
+# selection algorithm before the local clock is updated. Setting minsources to a larger number can be used to
+# improve the reliability, because multiple sources will need to correspond with each other.
 rhel9cis_chrony_server_minsources: 2
 
+
 ### 2.2 Special Purposes
-##### Service configuration booleans set true to keep service
+
+# Service configuration variables (boolean).
+# Set the respective variable to true to keep the service.
+# otherwise the service is stopped and disabled
+
+
+# This variable governs whether rules dealing with GUI specific packages(and/or their settings) should
+# be executed either to:
+# - secure GDM, if GUI is needed('rhel9cis_gui: true')
+# - or remove GDM and X-Windows-system, if no GUI is needed('rhel9cis_gui: false')
 rhel9cis_gui: false
+## Control 2.2.2 - Ensure Avahi Server is not installed
+# This variable, when set to false, will specify that Avahi Server packages should be uninstalled.
 rhel9cis_avahi_server: false
+## Control 2.2.3 -  Ensure CUPS is not installed
+# This variable, when set to false, will specify that CUPS(Common UNIX Printing System) package should be uninstalled.
 rhel9cis_cups_server: false
+## Control 2.2.4 - Ensure DHCP Server is not installed
+# This variable, when set to false, will specify that DHCP server package should be uninstalled.
 rhel9cis_dhcp_server: false
+## Control 2.2.5 - Ensure DNS Server is not installed
+# This variable, when set to false, will specify that DNS server package should be uninstalled.
 rhel9cis_dns_server: false
+## Control 2.2.14 - Ensure dnsmasq is not installed
+# This variable, when set to false, will specify that dnsmasq package should be uninstalled.
 rhel9cis_dnsmasq_server: false
+## Control 2.2.6 - Ensure VSFTP Server is not installed
+# This variable, when set to false, will specify that VSFTP server package should be uninstalled.
 rhel9cis_vsftpd_server: false
+## Control 2.2.7 - Ensure TFTP Server is not installed
+# This variable, when set to false, will specify that TFTP server package should be uninstalled.
 rhel9cis_tftp_server: false
+## Control 2.2.8 - Ensure a web server is not installed - HTTPD
+# This variable, when set to false, will specify that webserver packages(HTTPD) should be uninstalled.
 rhel9cis_httpd_server: false
+## Control 2.2.8 - Ensure a web server is not installed - NGINX
+# This variable, when set to false, will specify that webserver packages(NGINX) should be uninstalled.
 rhel9cis_nginx_server: false
+## Control 2.2.9 - Ensure IMAP and POP3 server is not installed - dovecot
+# This variable, when set to false, will specify that IMAP and POP3 servers(dovecot) should be uninstalled.
 rhel9cis_dovecot_server: false
+## Control 2.2.9 - Ensure IMAP and POP3 server is not installed - cyrus-imapd
+# This variable, when set to false, will specify that IMAP and POP3 servers(cyrus-imapd) should be uninstalled.
 rhel9cis_imap_server: false
+## Control 2.2.10 - Ensure Samba is not enabled
+# This variable, when set to false, will specify that 'samba' package should be uninstalled.
 rhel9cis_samba_server: false
+## Control 2.2.11 - Ensure HTTP Proxy Server is not installed
+# This variable, when set to false, will specify that 'squid' package should be uninstalled.
 rhel9cis_squid_server: false
+## Control 2.2.12 - Ensure net-snmp is not installed
+# This variable, when set to false, will specify that 'net-snmp' package should be uninstalled.
 rhel9cis_snmp_server: false
+## Control 2.2.13 - Ensure telnet-server is not installed
+# This variable, when set to false, will specify that 'telnet-server' package should be uninstalled.
 rhel9cis_telnet_server: false
+## Control 2.2.15 - Ensure mail transfer agent is configured for local-only mode
+# This variable, when system is NOT a mailserver, will configure Postfix to listen only on the loopback interface(the virtual
+# network interface that the server uses to communicate internally.
 rhel9cis_is_mail_server: false
 # Note the options
+# Client package configuration variables.
 # Packages are used for client services and Server- only remove if you dont use the client service
-#
+# Set the respective variable to `true` to keep the
+# client package, otherwise it is uninstalled (false).
 
+## Control 2.2.16 - Ensure nfs-utils is not installed or the nfs-server service is masked"
+# This variable specifies if the usage of NFS SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
+# NFS(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_nfs_service') with current one, respectively:
+# - if Server IS NOT needed('false') and:
+#    - Service IS NOT needed('rhel9cis_use_nfs_service: false'): 'nfs-utils' package will be removed
+#    - Service IS needed('rhel9cis_use_nfs_service: true'): impossible to need the service without the server
+# - if Server IS needed('true') and:
+#    - Service IS NOT needed('rhel9cis_use_nfs_service: false'): 'nfs-server' service will be masked
+#    - Service IS needed('rhel9cis_use_nfs_service: true'): Rule will be SKIPPED.
+#  | Server  | Service | Result                                                    |
+#  |---------|---------|-----------------------------------------------------------|
+#  | false   | false   | Remove package                                            |
+#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
+#  | true    | false   | Mask 'service'                                            |
+#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_nfs_server: false
+## Control 2.2.16 - Ensure nfs-utils is not installed or the nfs-server service is masked.
+# This variable specifies if the usage of NFS SERVICE is needed. If it's:
+#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
+#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being
+#    controlled by the var used in conjunction with current one:
+#          - removing 'nfs-utils' package('rhel9cis_use_nfs_server' set to 'false')
+#          - masking the 'nfs-server' service('rhel9cis_use_nfs_server' set to 'true')
 rhel9cis_use_nfs_service: false
 
+## Control 2.2.17 - Ensure rpcbind is not installed or the rpcbind services are masked
+# This variable specifies if the usage of RPC SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
+# RPC(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_rpc_service') with current one, respectively:
+# - if Server IS NOT needed('false') and:
+#    - Service IS NOT needed('rhel9cis_use_rpc_service: false'): 'rpcbind' package will be removed
+#    - Service IS needed('rhel9cis_use_rpc_service: true'): impossible to need the service without the server
+# - if Server IS needed('true') and:
+#    - Service IS NOT needed('rhel9cis_use_rpc_service: false'): 'rpcbind.socket' service will be masked
+#    - Service IS needed('rhel9cis_use_rpc_service: true'): Rule will be SKIPPED.
+#  | Server  | Service | Result                                                    |
+#  |---------|---------|-----------------------------------------------------------|
+#  | false   | false   | Remove package                                            |
+#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
+#  | true    | false   | Mask 'service'                                            |
+#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_rpc_server: false
+## Control 2.2.17 - Ensure rpcbind is not installed or the rpcbind services are masked
+# This variable specifies if the usage of RPC SERVICE is needed. If it's:
+#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
+#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being controlled by the var
+#     used in conjunction with current one:
+#          - removing 'rpcbind' package('rhel9cis_use_rpc_server' set to 'false')
+#          - masking the 'rpcbind.socket' service('rhel9cis_use_rpc_server' set to 'true')
 rhel9cis_use_rpc_service: false
 
+## Control 2.2.18 - Ensure rsync service is not enabled
+# This variable specifies if the usage of RSYNC SERVER is needed. Execution of the rule which secures (by uninstalling or masking service)
+# RSYNC(if it's NOT needed) will depend on the var used in conjunction('rhel9cis_use_rsync_service') with current one, respectively:
+# - if Server IS NOT needed('false') and:
+#    - Service IS NOT needed('rhel9cis_use_rsync_service: false'): 'rsync-daemon' package will be removed
+#    - Service IS needed('rhel9cis_use_rsync_service: true'): impossible to need the service without the server
+# - if Server IS needed('true') and:
+#    - Service IS NOT needed('rhel9cis_use_rsync_service: false'): 'rsyncd' service will be masked
+#    - Service IS needed('rhel9cis_use_rsync_service: true'): Rule will be SKIPPED.
+#  | Server  | Service | Result                                                    |
+#  |---------|---------|-----------------------------------------------------------|
+#  | false   | false   | Remove package                                            |
+#  | false   | true    | Needing 'service' without needing 'server' makes no sense |
+#  | true    | false   | Mask 'service'                                            |
+#  | true    | true    | SKIP RULE, BOTH 'service' and 'server' are required       |
 rhel9cis_use_rsync_server: false
+## Control 2.2.18 - Ensure rsync service is not enabled
+# This variable specifies if the usage of RSYNC SERVICE is needed. If it's:
+#   - needed('true'): rule which uninstalls/masks-service WILL NOT be executed at all
+#   - not needed('false'): rule which uninstalls/masks-service WILL be executed, its behavior being controlled by the var
+#     used in conjunction with current one:
+#          - removing 'rsync-daemon' package('rhel9cis_use_rsync_server' set to 'false')
+#          - masking the 'rsyncd' service('rhel9cis_use_rsync_server' set to 'true')
 rhel9cis_use_rsync_service: false
 
 #### 2.3 Service clients
+
+
+## Control - 2.3.1 - Ensure telnet client is not installed
+# Set this variable to `true` to keep package `telnet`; otherwise, the package is uninstalled.
 rhel9cis_telnet_required: false
+## Control - 2.3.2 - Ensure LDAP client is not installed
+# Set this variable to `true` to keep package `openldap-clients`; otherwise, the package is uninstalled.
 rhel9cis_openldap_clients_required: false
+## Control - 2.3.3 - Ensure FTP client is not installed
+# Set this variable to `true` to keep package `tftp`; otherwise, the package is uninstalled.
 rhel9cis_tftp_client: false
+## Control - 2.3.4 - Ensure FTP client is not installed
+# Set this variable to `true` to keep package `ftp`; otherwise, the package is uninstalled.
 rhel9cis_ftp_client: false
 
-## Section3 vars
+## Section 3 vars for
 ## Sysctl
+
+
+# This variable governs if the task which updates sysctl(including sysctl reload) is executed.
+# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_sysctl_update: false
+# This variable governs if the task which flushes the IPv4 routing table is executed(forcing subsequent connections to
+# use the new configuration).
+# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_flush_ipv4_route: false
+# This variable governs if the task which flushes the IPv6 routing table is executed(forcing subsequent connections to
+# use the new configuration).
+# NOTE: The current default value is likely to be overriden by other further tasks(via 'set_fact').
 rhel9cis_flush_ipv6_route: false
 
-### Firewall Service - either firewalld, iptables, or nftables
+### Firewall Service to install and configure - Options are:
+# 1) either 'firewalld'
+# 2) or 'nftables'
 #### Some control allow for services to be removed or masked
 #### The options are under each heading
 #### absent = remove the package
 #### masked = leave package if installed and mask the service
 rhel9cis_firewall: firewalld
 
-##### firewalld
+## Control 3.4.2.1 - Ensure firewalld default zone is set
+# This variable will set the firewalld default zone(that is used for everything that is not explicitly bound/assigned
+# to another zone): if there is no zone assigned to a connection, interface or source, only the default zone is used.
 rhel9cis_default_zone: public
 
 # These settings are added to demonstrate how this update can be done (eventually will require a new control)
@@ -512,24 +791,66 @@ rhel9cis_firewalld_ports:
     - number: 80
       protocol: tcp
 
-#### nftables
+## Controls 3.5.2.x - nftables
+
+
+## Control 3.4.2.2 - Ensure at least one nftables table exists
+# This variable governs if a table will be automatically created in nftables. Without a table (no default one), nftables
+# will not filter network traffic, so if this variable is set to 'false' and no tables exist, an alarm will be triggered!
 rhel9cis_nft_tables_autonewtable: true
+## Controls 3.4.2.{2|3|4|6|7} nftables
+# This variable stores the name of the table to be used when configuring nftables(creating chains, configuring loopback
+# traffic, established connections, default deny). If 'rhel9cis_nft_tables_autonewtable' is set as true, a new table will
+# be created using as name the value stored by this variable.
 rhel9cis_nft_tables_tablename: filter
+## Control 3.4.2.3 - Ensure nftables base chains exist
+# This variable governs if a nftables base chain(entry point for packets from the networking stack) will be automatically
+# created, if needed. Without a chain, a hook for input, forward, and delete, packets that would flow through those
+# chains will not be touched by nftables.
 rhel9cis_nft_tables_autochaincreate: true
 
-# Warning Banner Content (issue, issue.net, motd)
+## Controls:
+# - 1.7.1 - Ensure message of the day is configured properly
+# - 1.7.2 - Ensure local login warning banner is configured properly
+# - 1.7.3 - Ensure remote login warning banner is configured properly
+# This variable  stores the content for the Warning Banner(relevant for issue, issue.net, motd).
 rhel9cis_warning_banner: Authorized uses only. All activity may be monitored and reported.
 # End Banner
 
 ## Section4 vars
 ### 4.1 Configure System Accounting
 #### 4.1.2 Configure Data Retention
+## Controls what actions, when log files fill up
+# This variable controls how the audit system behaves when
+# log files are getting too full and space is getting too low.
 rhel9cis_auditd:
+    # This variable tells the system what action to take when the system has detected
+    # that it is starting to get low on disk space. Options are the same as for `admin_space_left_action`.
     space_left_action: email
+    # This variable should contain a valid email address or alias(default value is root),
+    # which will be used to send a warning when configured action is 'email'.
     action_mail_acct: root
+    # This variable determines the action the audit system should take when disk
+    # space runs low.
+    # The options for setting this variable are as follows:
+    # - `ignore`: the system does nothing when presented with the aforementioned issue;
+    # - `syslog`: a message is sent to the system log about disk space running low;
+    # - `suspend`: the system suspends recording audit events until more space is available;
+    # - `halt`: the system is halted when disk space is critically low.
+    # - `single`: the audit daemon will put the computer system in single user mode
+    # CIS prescribes either `halt` or `single`.
     admin_space_left_action: halt
     # The max_log_file parameter should be based on your sites policy.
     max_log_file: 10
+    # This variable determines what action the audit system should take when the maximum
+    # size of a log file is reached.
+    # The options for setting this variable are as follows:
+    # - `ignore`: the system does nothing when the size of a log file is full;
+    # - `syslog`: a message is sent to the system log indicating the problem;
+    # - `suspend`: the system suspends recording audit events until the log file is cleared or rotated;
+    # - `rotate`: the log file is rotated (archived) and a new empty log file is created;
+    # - `keep_logs`: the system attempts to keep as many logs as possible without violating disk space constraints.
+    # CIS prescribes the value `keep_logs`.
     max_log_file_action: keep_logs
 
 # This value governs if the below extra-vars for auditd should be used by the role
@@ -544,150 +865,390 @@ rhel9cis_auditd_extra_conf:
     space_left: 75
 
 # The audit_back_log_limit value should never be below 8192
+##  Control 4.1.1.4 - Ensure rhel9cis_audit_back_log_limit is sufficient
+# This variable represents the audit backlog limit, i.e., the maximum number of audit records that the
+# system can buffer in memory, if the audit subsystem is unable to process them in real-time.
+# Buffering in memory is useful in situations, where the audit system is overwhelmed
+# with incoming audit events, and needs to temporarily store them until they can be processed.
+# This variable should be set to a sufficient value. The CIS baseline recommends at least `8192` as value.
 rhel9cis_audit_back_log_limit: 8192
 
 ### 4.1.3.x audit template
+## Control 4.1.2.1 - Ensure audit log storage size is configured
+# This variable specifies the maximum size in MB that an audit log file can reach
+# before it is archived or deleted to make space for the new audit data.
+# This should be set based on your sites policy. CIS does not provide a specific value.
+rhel9cis_max_log_file_size: 10
+
+## Control 4.1.3.x - Audit template
+# This variable governs if the auditd logic should be executed(if value is true).
+# NOTE: The current default value is likely to be overriden(via 'set_fact') by other further tasks(in sub-section 'Auditd rules').
 update_audit_template: false
 
 ## Advanced option found in auditd post
+# This variable governs if defining user exceptions for auditd logging is acceptable.
 rhel9cis_allow_auditd_uid_user_exclusions: false
+# This variable contains a list of uids to be excluded(users whose actions are not logged by auditd)
+rhel9cis_auditd_uid_exclude:
+    - 1999
 
 ## Preferred method of logging
+## Control 'Configure other keys for auditd.conf' in 4.1.2.x section
+# The default auditd configuration should be suitable for most environments, but if your environment must
+# meet strict security policies, the extra configuration pairs used for securing auditd(by modifying
+# '/etc/audit/auditd.conf' file) can be stored within current variable.
 ## Whether rsyslog or journald preferred method for local logging
-## Affects rsyslog cis 4.2.1.3 and journald cis 4.2.2.5
+## Control 4.2.1 | Configure rsyslog
+## Control 4.2.2 | Configure journald
+# This variable governs which logging service should be used, choosing between 'rsyslog'(CIS recommendation)
+# or 'journald'(only one is implemented) will trigger the execution of the associated subsection, as the-best
+# practices are written wholly independent of each other.
 rhel9cis_syslog: rsyslog
+## Control 4.2.1.5 | PATCH | Ensure logging is configured
+# This variable governs if current Ansible role should manage syslog settings
+# in /etc/rsyslog.conf file, namely mail, news and misc(warn, messages)
 rhel9cis_rsyslog_ansiblemanaged: true
 
-#### 4.2.1.6 remote and destation log server name
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable governs if 'rsyslog' service should be automatically configured to forward messages to a
+# remote log server. If set to 'false', the configuration of the 'omfwd' plugin, used to provide forwarding
+# over UDP or TCP, will not be performed.
 rhel9cis_remote_log_server: false
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the value of the 'target' parameter to be configured when enabling
+# forwarding syslog messages to a remote log server, thus configuring the actual FQDN/IP address of the
+# destination server. For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_host: logagg.example.com
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the value of the 'port' parameter to be configured when enabling
+# forwarding syslog messages to a remote log server. The default value for this destination port is 514.
+# For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_port: 514
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the value("TCP"/"UDP") of the 'protocol' parameter to be configured when enabling
+# forwarding syslog messages to a remote log server. The default value for the 'omfwd' plug-in is UDP.
+# For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_protocol: tcp
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable governs how often an action is retried(value is passed to 'action.resumeRetryCount' parameter) before
+# it is considered to have failed(that roughly translates to discarded messages). The default value is 0, but
+# when set to "-1"(eternal), this setting would prevent rsyslog from dropping messages when retrying to connect
+# if server is not responding. For this value to be reflected in the configuration, the variable which enables the
+# automatic configuration of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_retrycount: 100
+## Control 4.2.1.6 - Ensure rsyslog is configured to send logs to a remote log host
+# This variable configures the maximum number of messages that can be hold(value is passed to 'queue.size' parameter).
+# For this value to be reflected in the configuration, the variable which enables the automatic configuration
+# of rsyslog forwarding must be enabled('rhel9cis_remote_log_server: true').
 rhel9cis_remote_log_queuesize: 1000
 
-#### 4.2.1.7
+## Control 4.2.1.7 - Ensure rsyslog is not configured to receive logs from a remote client
+# This variable expresses whether the system is used as a log server or not. If set to:
+#  - 'false', current system will act as a log CLIENT, thus it should NOT receive data from other hosts.
+#  - 'true', current system will act as a log SERVER, enabling centralised log management(by protecting log integrity
+# from local attacks on remote clients)
 rhel9cis_system_is_log_server: false
 
-# 4.2.2.1.2
-# rhel9cis_journal_upload_url is the ip address to upload the journal entries to
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# 'rhel9cis_journal_upload_url' is the ip address to upload the journal entries to
+#  URL value may specify either just the hostname or both the protocol and hostname. 'https' is the default. The port
+#  number may be specified after a colon (":"), otherwise 19532 will be used by default.
 rhel9cis_journal_upload_url: 192.168.50.42
-# The paths below have the default paths/files, but allow user to create custom paths/filenames
+## The paths below have the default paths/files, but allow user to create custom paths/filenames
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# This variable specifies the path to the private key file used by the remote journal
+# server to authenticate itself to the client. This key is used alongside the server's
+# public certificate to establish secure communication.
 rhel9cis_journal_upload_serverkeyfile: "/etc/ssl/private/journal-upload.pem"
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# This variable specifies the path to the public certificate file of the remote journal
+# server. This certificate is used to verify the authenticity of the remote server.
 rhel9cis_journal_servercertificatefile: "/etc/ssl/certs/journal-upload.pem"
+## Control 4.2.2.1.2 - Ensure systemd-journal-remote is configured
+# This variable specifies the path to a file containing one or more public certificates
+# of certificate authorities (CAs) that the client trusts. These trusted certificates are used
+# to validate the authenticity of the remote server's certificate.
 rhel9cis_journal_trustedcertificatefile: "/etc/ssl/ca/trusted.pem"
+# ATTENTION: Uncomment the keyword below when values are set!
 
-# 4.2.2.1
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# Current variable configures the max amount of disk space the logs will use(thus, journal files
+# will not grow without bounds)
 # The variables below related to journald, please set these to your site specific values
-# rhel9cis_journald_systemmaxuse is the max amount of disk space the logs will use
+# These variable specifies how much disk space the journal may use up at most
+# Specify values in bytes or use K, M, G, T, P, E as units for the specified sizes.
+# See https://www.freedesktop.org/software/systemd/man/journald.conf.html for more information.
 rhel9cis_journald_systemmaxuse: 10M
-# rhel9cis_journald_systemkeepfree is the amount of disk space to keep free
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# Current variable configures the amount of disk space to keep free for other uses.
 rhel9cis_journald_systemkeepfree: 100G
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# This variable configures how much disk space the journal may use up at most.
+# Similar with 'rhel9cis_journald_systemmaxuse', but related to runtime space.
 rhel9cis_journald_runtimemaxuse: 10M
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# This variable configures the actual amount of disk space to keep free
+# Similar with 'rhel9cis_journald_systemkeepfree', but related to runtime space.
 rhel9cis_journald_runtimekeepfree: 100G
-# rhel9cis_journald_MaxFileSec is how long in time to keep log files. Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
+## Control 4.2.2.6 - Ensure journald log rotation is configured per site policy
+# Current variable governs the settings for log retention(how long the log files will be kept).
+# Thus, it specifies the maximum time to store entries in a single journal
+# file before rotating to the next one. Set to 0 to turn off this feature.
+# The given values is interpreted as seconds, unless suffixed with the units
+# `year`, `month`, `week`, `day`, `h` or `m` to override the default time unit of seconds.
+# Values are Xm, Xh, Xday, Xweek, Xmonth, Xyear, for example 2week is two weeks
+# ATTENTION: Uncomment the keyword below when values are set!
 rhel9cis_journald_maxfilesec: 1month
 
-#### 4.3
+## Control 4.3 - Ensure logrotate is configured
+# This variable defines the log file rotation period.
+# Options are: daily, weekly, monthly, yearly.
 rhel9cis_logrotate: "daily"
 
 ## Section5 vars
 
-# This will allow use of drop in files when CIS adopts them.
+## Section 5.2 - SSH
+
+# This value, containing the absolute filepath of the produced 'sshd' config file, allows usage of
+# drop-in files('/etc/ssh/ssh_config.d/{ssh_drop_in_name}.conf', supported by RHEL9) when CIS adopts them.
+# Otherwise, the default value is '/etc/ssh/ssh_config'.
 rhel9_cis_sshd_config_file: /etc/ssh/sshd_config
 
+## Controls:
+## - 5.2.4  - Ensure SSH access is limited
+## - 5.2.19 - Ensure SSH LoginGraceTime is set to one minute or less
+## - 5.2.20 - Ensure SSH Idle Timeout Interval is configured
 rhel9cis_sshd:
+    # This variable sets the maximum number of unresponsive "keep-alive" messages
+    # that can be sent from the server to the client before the connection is considered
+    # inactive and thus, closed.
     clientalivecountmax: 0
+    # This variable sets the time interval in seconds between sending "keep-alive"
+    # messages from the server to the client. These types of messages are intended to
+    # keep the connection alive and prevent it being terminated due to inactivity.
     clientaliveinterval: 900
+    # This variable specifies the amount of seconds allowed for successful authentication to
+    # the SSH server.
     logingracetime: 60
     # WARNING: make sure you understand the precedence when working with these values!!
     # allowusers:
     # allowgroups: systems dba
     # denyusers:
     # denygroups:
+    # This variable, if specified, configures a list of USER name patterns, separated by spaces, to allow SSH
+    # access for users whose user name matches one of the patterns. This is done
+    # by setting the value of `AllowUsers` option in `/etc/ssh/sshd_config` file.
+    # If an USER@HOST format will be used, the specified user will be allowed only on that particular host.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, see https://linux.die.net/man/5/sshd_config
+    allow_users: ""
+    # (String) This variable, if spcieifed, configures a list of GROUP name patterns, separated by spaces, to allow SSH access
+    # for users whose primary group or supplementary group list matches one of the patterns. This is done
+    # by setting the value of `AllowGroups` option in `/etc/ssh/sshd_config` file.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, https://linux.die.net/man/5/sshd_config
+    allow_groups: "wheel"
+    # This variable, if specified, configures a list of USER name patterns, separated by spaces, to prevent SSH access
+    # for users whose user name matches one of the patterns. This is done
+    # by setting the value of `DenyUsers` option in `/etc/ssh/sshd_config` file.
+    # If an USER@HOST format will be used, the specified user will be restricted only on that particular host.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, see https://linux.die.net/man/5/sshd_config
+    deny_users: "nobody"
+    # This variable, if specified, configures a list of GROUP name patterns, separated by spaces, to prevent SSH access
+    # for users whose primary group or supplementary group list matches one of the patterns. This is done
+    # by setting the value of `DenyGroups` option in `/etc/ssh/sshd_config` file.
+    # The allow/deny directives process order: DenyUsers, AllowUsers, DenyGroups, AllowGroups.
+    # For more info, see https://linux.die.net/man/5/sshd_config
+    deny_groups: ""
 
-# 5.2.5 SSH LogLevel setting. Options are INFO or VERBOSE
+## Control 5.2.5 - Ensure SSH LogLevel is appropriate
+# This variable is used to control the verbosity of the logging produced by the SSH server.
+# The options for setting it are as follows:
+# - `QUIET`: Minimal logging;
+# - `FATAL`: logs only fatal errors;
+# - `ERROR`: logs error messages;
+# - `INFO`: logs informational messages in addition to errors;
+# - `VERBOSE`: logs a higher level of detail, including login attempts and key exchanges;
+# - `DEBUG`: generates very detailed debugging information including sensitive information.
+# - `DEBUG(x)`: Whereas x = debug level 1 to 3, DEBUG=DEBUG1.
 rhel9cis_ssh_loglevel: INFO
 
-# 5.2.19 SSH MaxSessions setting. Must be 4 our less
+## Control 5.2.18 - Ensure SSH MaxSessions is set to 10 or less
+# This variable value specifies the maximum number of open sessions that are permitted from
+# a given location
 rhel9cis_ssh_maxsessions: 4
-rhel9cis_inactivelock:
-    lock_days: 30
 
+## Control 5.6.1.4 - Ensure inactive password lock is 30 days or less
+rhel9cis_inactivelock:
+# This variable specifies the number of days of inactivity before an account will be locked.
+# CIS requires a value of 30 days or less.
+    lock_days: 30
+# This variable governs if authconfig package should be installed. This package provides a simple method of
+# configuring /etc/sysconfig/network to handle NIS, as well as /etc/passwd and /etc/shadow, the files used
+# for shadow password support. Basic LDAP, Kerberos 5, and Winbind client configuration is also provided.
 rhel9cis_use_authconfig: false
-# 5.3.1/5.3.2 Custom authselect profile settings. Settings in place now will fail, they are place holders from the control example
-# Due to the way many multiple options and ways to configure this control needs to be enabled and settings adjusted to minimise risk
+
+## Section 5.4 - Configure authselect: Custom authselect profile settings(name, profile to customize, options)
+## Controls:
+#  - 5.4.1 - Ensure custom authselect profile is used('custom_profile_name', 'default_file_to_copy' subsettings)
+#  - 5.4.2 - Ensure authselect includes with-faillock | with auth select profile('custom_profile_name')
+# Settings in place now will fail, they are placeholders from the control example. Due to the way many multiple
+# options and ways to configure this control needs to be enabled and settings adjusted to minimise risk.
 rhel9cis_authselect:
+    # This variable configures the name of the custom profile to be created and selected.
     custom_profile_name: custom-profile
+    # This variable configures the ID of the existing profile that should be used as a base for the new profile.
     default_file_to_copy: "sssd --symlink-meta"
     options: with-sudo with-faillock without-nullok
 
-# 5.3.1 Enable automation to create custom profile settings, using the settings above
+## Control 5.4.1 - Ensure custom authselect profile is used
+# This variable governs if an authselect custom profile should be automatically created, by copying and
+# customizing one of the default profiles. The default profiles include: sssd, winbind, or the nis. This profile can then be
+# customized to follow site specific requirements.
 rhel9cis_authselect_custom_profile_create: false
 
-# 5.3.2 Enable automation to select custom profile options, using the settings above
+## Control 5.4.2 - Ensure authselect includes with-faillock | Create custom profiles
+# This variable governs if the existing custom profile should be selected(Note: please keep in mind that all future updates
+# to the PAM templates and meta files in the original profile will be reflected in your custom profile, too.)
 rhel9cis_authselect_custom_profile_select: false
 
+## Section 5.6.1.x: Shadow Password Suite Parameters
 rhel9cis_pass:
+    ## Control 5.6.1.1 - Ensure password expiration is 365 days or less
+    # This variable governs after how many days a password expires.
+    # CIS requires a value of 365 or less.
     max_days: 365
+    ## Control 5.6.1.2 - Ensure minimum days between password changes is 7 or more
+    # This variable specifies the minimum number of days allowed between changing
+    # passwords. CIS requires a value of at least 1.
     min_days: 7
+    ## Control 5.6.1.3 - Ensure password expiration warning days is 7 or more
+    # This variable governs, how many days before a password expires, the user will be warned.
+    # CIS requires a value of at least 7.
     warn_age: 7
 
-# 5.5.1
-## PAM
+## Control 5.5.1 - Ensure password creation requirements are configured  - PAM
 rhel9cis_pam_password:
+    # This variable sets the minimum chars a password needs to be set.
     minlen: 14
+    # This variable set password complexity,the minimum number of
+    # character types that must be used (i.e., uppercase, lowercase, digits, other)
+    # Set to 2, passwords cannot have all lower/upper case.
+    # Set to 3, passwords needs numbers.
+    # set to 4, passwords will have to include all four types of characters.
     minclass: 4
 
+## Controls
+# - 5.5.2 - Ensure lockout for failed password attempts is configured
+# - 5.5.3 - Ensure password reuse is limited
+# - 5.5.4 - Ensure password hashing algorithm is SHA-512
+# - 5.4.2 -  Ensure authselect includes with-faillock
 rhel9cis_pam_faillock:
+    # This variable sets the amount of time a user will be unlocked after the max amount of
+    #   password failures.
     unlock_time: 900
+    # This variable sets the amount of tries a password can be entered, before a user is locked.
     deny: 5
+    # This variable represents the number of password change cycles, after which
+    # an user can re-use a password.
+    # CIS requires a value of 5 or more.
     remember: 5
 
 # UID settings for interactive users
 # These are discovered via logins.def if set true
 discover_int_uid: false
+### Controls:
+# - 5.6.2 -  Ensure system accounts are secured
+# - 6.2.10 - Ensure local interactive user home directories exist
+# - 6.2.11 - Ensure local interactive users own their home directories
+# This variable sets the minimum number from which to search for UID
+# Note that the value will be dynamically overwritten if variable `dicover_int_uid` has
+# been set to `true`.
 min_int_uid: 1000
+### Controls:
+# - 6.2.10 - Ensure local interactive user home directories exist
+# - 6.2.11 - Ensure local interactive users own their home directories
+# This variable sets the maximum number at which the search stops for UID
+# Note that the value will be dynamically overwritten if variable `dicover_int_uid` has
+# been set to `true`.
 max_int_uid: 65533
 
-# 5.3.3 var log location variable
+## Control 5.3.3 - Ensure sudo log file exists
+# By default, sudo logs through syslog(3). However, to specify a custom log file, the
+# 'logfile' parameter will be used, setting it with current variable's value.
+# This variable defines the path and file name of the sudo log file.
 rhel9cis_sudolog_location: "/var/log/sudo.log"
 
-#### 5.3.6
+## Control 5.3.6 -Ensure sudo authentication timeout is configured correctly
+# This variable sets the duration (in minutes) during which a user's authentication credentials
+# are cached after successfully authenticating using "sudo". This allows the user to execute
+# multiple commands with elevated privileges without needing to re-enter their password for each
+# command within the specified time period. CIS requires a value of at most 15 minutes.
 rhel9cis_sudo_timestamp_timeout: 15
 
-### 5.4.2 authselect and faillock
+## Control 5.4.2 - authselect and faillock
 ## This option is used at your own risk it will enable faillock for users
 ## Only to be used on a new clean system if not using authselect
-## THIS CAN BREAK ACCESS EVEN FOR ROOT - UNDERSTAND RISKS ##
+## THIS CAN BREAK ACCESS EVEN FOR ROOT - PLEASE UNDERSTAND RISKS !
 rhel9cis_add_faillock_without_authselect: false
-# This needs to be set to ACCEPT
+# This needs to be set to 'ACCEPT'(as string), besides setting 'rhel9cis_add_faillock_without_authselect'
+# to 'true', in order to include the 'with-failock' option to the current authselect profile.
 rhel9cis_5_4_2_risks: NEVER
 
-# RHEL-09-5.4.5
+## Control 5.6.3 - Ensure default user shell timeout is 900 seconds or less
 # Session timeout setting file (TMOUT setting can be set in multiple files)
 # Timeout value is in seconds. (60 seconds * 10 = 600)
 rhel9cis_shell_session_timeout:
+    # This variable specifies the path of the timeout setting file.
+    # (TMOUT setting can be set in multiple files, but only one is required for the
+    # rule to pass. Options are:
+    # - a file in `/etc/profile.d/` ending in `.s`,
+    # - `/etc/profile`, or
+    # - `/etc/bash.bashrc`.
     file: /etc/profile.d/tmout.sh
+    # This variable represents the amount of seconds a command or process is allowed to
+    # run before being forcefully terminated.
+    # CIS requires a value of at most 900 seconds.
     timeout: 600
-# RHEL-09-5.4.1.5 Allow ansible to expire password for account with a last changed date in the future. False will just display users in violation, true will expire those users passwords
+
+## Control 5.6.1.5 - Ensure all users last password change date is in the past
+# Allow ansible to expire password for account with a last changed date in the future. Setting it
+# to 'false' will just display users in violation, while 'true' will expire those users passwords.
 rhel9cis_futurepwchgdate_autofix: true
 
-# 5.3.7
+## Control 5.3.7 - Ensure access to the 'su' command is restricted
+# This variable determines the name of the group of users that are allowed to use the su command.
+# CIS requires that such a group be CREATED(named according to site policy) and be kept EMPTY.
 rhel9cis_sugroup: nosugroup
 
 ## Section6 vars
 
-# RHEL-09_6.1.1
+## Control 6.1.15 - Audit system file permissions | Create list and warning
+# The RPM package-manager has many useful options. For example, using option:
+#  - '-V': RPM can automatically check if system packages are correctly installed
+#  - '-qf': RPM can be used to determine which package a particular file belongs to
+# Auditing system file-permissions takes advantage of the combination of those two options and, therefore, is able to
+# detect any discrepancy regarding installed packages, redirecting the output of this combined
+# command into a specific file. If no output is returned, the package is installed correctly.
+# Current variable stores the preferred absolute filepath for such a file, therefore if this file
+# contains any lines, an alert message will be generated to warn about each discrepancy.
 rhel9cis_rpm_audit_file: /var/tmp/rpm_file_check
 
-# RHEL-09_6.1.10 Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable
+## Control 6.1.9 - Ensure no world writable files exist
+# Allow ansible to adjust world-writable files. False will just display world-writable files, True will remove world-writable.
 rhel9cis_no_world_write_adjust: true
+
 rhel9cis_passwd_label: "{{ (this_item | default(item)).id }}: {{ (this_item | default(item)).dir }}"
 
-# 6.2.16
-## Dont follow symlinks for changes to user home directory thanks to @dulin-gnet and comminty for rhel8-cis reedbacj
+## Control 6.2.16 - Ensure local interactive user dot files are not group or world writable
+# This boolean variable governs if current role should follow filesystem links for changes to
+# user home directory.
 rhel_09_6_2_16_home_follow_symlinks: false
+# thanks to @dulin-gnet and community for rhel8-cis feedback.
 
 #### Goss Configuration Settings ####
 # Set correct env for the run_audit.sh script from https://github.com/ansible-lockdown/{{ benchmark }}-Audit.git"

--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -24,28 +24,17 @@
 
 - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
   block:
-      - name: "4.1.1.2 | AUDIT | Ensure auditing for processes that start prior to auditd is enabled | Get GRUB_CMDLINE_LINUX"
-        ansible.builtin.shell: grep 'GRUB_CMDLINE_LINUX=' /etc/default/grub | sed 's/.$//'
+      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby existence of current value"
+        ansible.builtin.shell: grubby --info=ALL | grep args | grep -o -E "audit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"
         changed_when: false
         failed_when: false
         check_mode: false
-        register: rhel9cis_4_1_1_2_grub_cmdline_linux
+        register: rhel9cis_4_1_1_2_grubby_curr_value_audit_linux
 
-      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Replace existing setting"
-        ansible.builtin.replace:
-            path: /etc/default/grub
-            regexp: 'audit=.'
-            replace: 'audit=1'
-        notify: Grub2cfg
-        when: "'audit=' in rhel9cis_4_1_1_2_grub_cmdline_linux.stdout"
-
-      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Add audit setting if missing"
-        ansible.builtin.lineinfile:
-            path: /etc/default/grub
-            regexp: '^GRUB_CMDLINE_LINUX='
-            line: '{{ rhel9cis_4_1_1_2_grub_cmdline_linux.stdout }} audit=1"'
-        notify: Grub2cfg
-        when: "'audit=' not in rhel9cis_4_1_1_2_grub_cmdline_linux.stdout"
+      - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby update, if needed"
+        ansible.builtin.shell: grubby --update-kernel=ALL --args="audit=1"
+        when:
+            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux | int != 1
   when:
       - rhel9cis_rule_4_1_1_2
   tags:
@@ -58,28 +47,17 @@
 
 - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient"
   block:
-      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Get GRUB_CMDLINE_LINUX"
-        ansible.builtin.shell: grep 'GRUB_CMDLINE_LINUX=' /etc/default/grub | sed 's/.$//'
+      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby existence of current value"
+        ansible.builtin.shell: grubby --info=ALL | grep args | grep -o -E "audit_backlog_limit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"
         changed_when: false
         failed_when: false
         check_mode: false
-        register: rhel9cis_4_1_1_3_grub_cmdline_linux
+        register: rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux
 
-      - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient | Replace existing setting"
-        ansible.builtin.replace:
-            path: /etc/default/grub
-            regexp: 'audit_backlog_limit=\d+'
-            replace: 'audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}'
-        notify: Grub2cfg
-        when: "'audit_backlog_limit=' in rhel9cis_4_1_1_3_grub_cmdline_linux.stdout"
-
-      - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient | Add audit_backlog_limit setting if missing"
-        ansible.builtin.lineinfile:
-            path: /etc/default/grub
-            regexp: '^GRUB_CMDLINE_LINUX='
-            line: '{{ rhel9cis_4_1_1_3_grub_cmdline_linux.stdout }} audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"'
-        notify: Grub2cfg
-        when: "'audit_backlog_limit=' not in rhel9cis_4_1_1_3_grub_cmdline_linux.stdout"
+      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby update, if needed"
+        ansible.builtin.shell: grubby --update-kernel=ALL --args="audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"
+        when:
+            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout | int < rhel9cis_audit_back_log_limit
   when:
       - rhel9cis_rule_4_1_1_3
   tags:

--- a/tasks/section_5/cis_5.6.x.yml
+++ b/tasks/section_5/cis_5.6.x.yml
@@ -98,11 +98,37 @@
             regexp: '^USERGROUPS_ENAB'
             line: USERGROUPS_ENAB no
 
-      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Force umask sessions /etc/pam.d/system-auth"
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Check umask.so in system-auth"
+        shell: |
+            grep -E -q "^session\s*(optional|requisite|required)\s*pam_umask.so$" /etc/pam.d/system-auth
+        ignore_errors: true
+        no_log: true
+        check_mode: true
+        register: pam_umask_line_present_system
+
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in system-auth"
         ansible.builtin.lineinfile:
-            path: /etc/pam.d/system-auth
-            line: 'session     required            pam_umask.so'
-            insertafter: EOF
+            path: "/etc/pam.d/system-auth"
+            regexp: '^session\s*(optional|requisite|required)\s*pam_umask.so$'
+            line: 'session    optional    pam_umask.so'
+        when:
+            - pam_umask_line_present_system.rc | int != 0
+
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Check umask.so in password-auth"
+        shell: |
+            grep -E -q "^session\s*(optional|requisite|required)\s*pam_umask.so$" /etc/pam.d/password-auth
+        ignore_errors: true
+        no_log: true
+        check_mode: true
+        register: pam_umask_line_present_password
+
+      - name: "5.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | If needed, load session umask.so in password-auth"
+        ansible.builtin.lineinfile:
+            path: "/etc/pam.d/password-auth"
+            regexp: '^session\s*(optional|requisite|required)\s*pam_umask.so$'
+            line: 'session    optional    pam_umask.so'
+        when:
+            - pam_umask_line_present_password.rc | int != 0
   when:
       - rhel9cis_rule_5_6_5
   tags:


### PR DESCRIPTION
CountMax: 0 -> 3

**Overall Review of Changes:**
Use correct value

**Issue Fixes:**
#170

**Enhancements:**
Use correct value



**Extra question(not about `ClientAliveCountMax`), but about `ClientAliveInterval`**

- [ ] @uk-bolly, CIS says: 

Edit the /etc/ssh/sshd_config file to set the parameters according to site policy.
Example:
```
ClientAliveInterval 15            -> T??
ClientAliveCountMax 3
```
Current `devel` branch  uses 900(seconds), is there a good reason why we're not following a value close to ~15(CIS-recommended value) 
Anyhow, for both 900 and 15 seconds, CIS returns a PASS.

**How has this been tested?:**
EC2
