### PR TITLE
oscap scannner found 2 issues in sshd configuration override files

### DIFF
--- a/tasks/section_5/cis_5.2.x.yml
+++ b/tasks/section_5/cis_5.2.x.yml
@@ -232,11 +232,21 @@
       - rule_5.2.11
 
 - name: "5.2.12 | PATCH | Ensure SSH X11 forwarding is disabled"
-  ansible.builtin.lineinfile:
-      path: "{{ rhel9_cis_sshd_config_file }}"
-      regexp: "^#X11Forwarding|^X11Forwarding"
-      line: 'X11Forwarding no'
-      validate: sshd -t -f %s
+  block:
+
+      - name: "5.2.12 | PATCH | Ensure SSH X11 forwarding is disabled | config file"
+        ansible.builtin.lineinfile:
+            path: "{{ rhel9_cis_sshd_config_file }}"
+            regexp: "^#X11Forwarding|^X11Forwarding"
+            line: 'X11Forwarding no'
+            validate: sshd -t -f %s
+
+      - name: "5.2.12 | PATCH | Ensure SSH X11 forwarding is disabled | override"
+        ansible.builtin.lineinfile:
+            path: /etc/ssh/sshd_config.d/50-redhat.conf
+            regexp: "^#X11Forwarding|^X11Forwarding"
+            line: 'X11Forwarding no'
+            validate: sshd -t -f %s
   when:
       - rhel9cis_rule_5_2_12
   tags:

--- a/tasks/section_5/cis_5.2.x.yml
+++ b/tasks/section_5/cis_5.2.x.yml
@@ -150,11 +150,18 @@
       - rule_5.2.6
 
 - name: "5.2.7 | PATCH | Ensure SSH root login is disabled"
-  ansible.builtin.lineinfile:
-      path: "{{ rhel9_cis_sshd_config_file }}"
-      regexp: "^#PermitRootLogin|^PermitRootLogin"
-      line: 'PermitRootLogin no'
-      validate: sshd -t -f %s
+  block:
+      - name: "5.2.7 | PATCH | Ensure SSH root login is disabled | config file"
+        ansible.builtin.lineinfile:
+            path: "{{ rhel9_cis_sshd_config_file }}"
+            regexp: "^#PermitRootLogin|^PermitRootLogin"
+            line: 'PermitRootLogin no'
+            validate: sshd -t -f %s
+
+      - name: "5.2.7 | PATCH | Ensure SSH root login is disabled | override file"
+        ansible.builtin.file:
+            path: /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+            state: absent
   when:
       - rhel9cis_rule_5_2_7
   tags:


### PR DESCRIPTION
**Overall Review of Changes:**
We like control over `PermitRootLogin` and `X11Forwarding`.
We should also fix the config files created by the installer.

**Issue Fixes:**
-

**Enhancements:**
-

**How has this been tested?:**
```yaml
---

- name: Security Audit
  hosts: all
  become: true
  gather_facts: true

  pre_tasks:

    - name: Install packages
      ansible.builtin.package:
        state: present
        name:
          - openscap-scanner
          - scap-security-guide

  post_tasks:

    - name: Run CIS oscap scan and create /tmp/report.html
      ansible.builtin.command:
        oscap xccdf eval --profile cis \
          --report /tmp/report.html \
          /usr/share/xml/scap/ssg/content/ssg-almalinux9-ds.xml
      changed_when: true
      no_log: false
      register: scan_return
      failed_when: scan_return.stdout is not defined

    - name: Set permissions
      ansible.builtin.file:
        path: /tmp/report.html
        owner: "{{ ansible_ssh_user }}"
        mode: '0600'
```

