### PR TITLE
fix: idempotency molecule issue fixed for logfiles #173

### DIFF
--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -13,7 +13,7 @@
       - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | change permissions"
         ansible.builtin.file:
             path: "{{ item.path }}"
-            mode: '0640'
+            mode: "{% if item.mode != '0600' %}0640{% endif %}"
         loop: "{{ logfiles.files }}"
         loop_control:
             label: "{{ item.path }}"

--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -13,7 +13,7 @@
       - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | change permissions"
         ansible.builtin.file:
             path: "{{ item.path }}"
-            mode: "{{ '0640' if item.mode != '0600' else '0600' }}"
+            mode: "{{ '0600' if item.mode == '0600' else '0640' }}"
         loop: "{{ logfiles.files }}"
         loop_control:
             label: "{{ item.path }}"

--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -13,7 +13,7 @@
       - name: "4.2.3 | PATCH | Ensure permissions on all logfiles are configured | change permissions"
         ansible.builtin.file:
             path: "{{ item.path }}"
-            mode: "{% if item.mode != '0600' %}0640{% endif %}"
+            mode: "{{ '0640' if item.mode != '0600' else '0600' }}"
         loop: "{{ logfiles.files }}"
         loop_control:
             label: "{{ item.path }}"


### PR DESCRIPTION
**Overall Review of Changes:**
A general description of the changes made that are being requested for merge
4.2.3 | PATCH | Ensure permissions on all logfiles are configured  -- this was not idempotent for the audit log. 
if the audit.conf has log_group set to root it will rotate the permissions back to 0600. (tested with AWS ec2/ Azure vms) 
This caused a failure in my own molecule testing in the second run. 

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses
#173  is fixed with this MR

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A
Tested from a cis-wrapper role which spins up vagrant vms in aws. First run went fine, second run detected changes. This will fix the prevent changes in de second run on the /var/log/audit/audit.log. 
