### PR TITLE
Bugfix 5 3 4 against issue #176

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,24 +33,24 @@
         ansible.builtin.debug:
             msg: "No local account found for {{ ansible_env.SUDO_USER }} user. Skipping local account checks."
         when:
-          - rhel9cis_ansible_user_password_set.stdout == "not found"
+            - rhel9cis_ansible_user_password_set.stdout == "not found"
       - name: "Check local account"
         block:
-          - name: "Check password set for {{ ansible_env.SUDO_USER }} | Assert local password set"
-            ansible.builtin.assert:
-                that:
-                  - rhel9cis_ansible_user_password_set.stdout | length != 0
-                  - rhel9cis_ansible_user_password_set.stdout != "!!"
-                fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
-                success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user"
-          - name: "Check account is not locked for {{ ansible_env.SUDO_USER }} | Assert local account not locked"
-            ansible.builtin.assert:
-                that:
-                  - not rhel9cis_ansible_user_password_set.stdout.startswith("!")
-                fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} is locked - It can break access"
-                success_msg: "The local account is not locked for {{ ansible_env.SUDO_USER }} user"
+            - name: "Check password set for {{ ansible_env.SUDO_USER }} | Assert local password set"
+              ansible.builtin.assert:
+                  that:
+                      - rhel9cis_ansible_user_password_set.stdout | length != 0
+                      - rhel9cis_ansible_user_password_set.stdout != "!!"
+                  fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
+                  success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user"
+            - name: "Check account is not locked for {{ ansible_env.SUDO_USER }} | Assert local account not locked"
+              ansible.builtin.assert:
+                  that:
+                      - not rhel9cis_ansible_user_password_set.stdout.startswith("!")
+                  fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} is locked - It can break access"
+                  success_msg: "The local account is not locked for {{ ansible_env.SUDO_USER }} user"
         when:
-          - rhel9cis_ansible_user_password_set.stdout != "not found"
+            - rhel9cis_ansible_user_password_set.stdout != "not found"
   when:
       - rhel9cis_rule_5_3_4
       - ansible_env.SUDO_USER is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,19 +23,34 @@
 - name: "Check password set for {{ ansible_env.SUDO_USER }}"
   block:
       - name: "Check password set for {{ ansible_env.SUDO_USER }} | password state"
-        ansible.builtin.shell: "grep {{ ansible_env.SUDO_USER }} /etc/shadow | awk -F: '{print $2}'"
+        ansible.builtin.shell: "(grep {{ ansible_env.SUDO_USER }} /etc/shadow || echo 'not found:not found') | awk -F: '{print $2}'"
         changed_when: false
         failed_when: false
         check_mode: false
         register: rhel9cis_ansible_user_password_set
 
-      - name: "Check password set for {{ ansible_env.SUDO_USER }} | Assert password set and not locked"
-        ansible.builtin.assert:
-            that: rhel9cis_ansible_user_password_set.stdout | length != 0 and rhel9cis_ansible_user_password_set.stdout != "!!"
-            fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
-            success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user"
-        vars:
-            sudo_password_rule: rhel9cis_rule_5_3_4  # pragma: allowlist secret
+      - name: "Check for local account {{ ansible_env.SUDO_USER }} | Check for local account"
+        ansible.builtin.debug:
+            msg: "No local account found for {{ ansible_env.SUDO_USER }} user. Skipping local account checks."
+        when:
+          - rhel9cis_ansible_user_password_set.stdout == "not found"
+      - name: "Check local account"
+        block:
+          - name: "Check password set for {{ ansible_env.SUDO_USER }} | Assert local password set"
+            ansible.builtin.assert:
+                that:
+                  - rhel9cis_ansible_user_password_set.stdout | length != 0
+                  - rhel9cis_ansible_user_password_set.stdout != "!!"
+                fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
+                success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user"
+          - name: "Check account is not locked for {{ ansible_env.SUDO_USER }} | Assert local account not locked"
+            ansible.builtin.assert:
+                that:
+                  - not rhel9cis_ansible_user_password_set.stdout.startswith("!")
+                fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} is locked - It can break access"
+                success_msg: "The local account is not locked for {{ ansible_env.SUDO_USER }} user"
+        when:
+          - rhel9cis_ansible_user_password_set.stdout != "not found"
   when:
       - rhel9cis_rule_5_3_4
       - ansible_env.SUDO_USER is defined
@@ -43,6 +58,8 @@
   tags:
       - user_passwd
       - rule_5.3.4
+  vars:
+      sudo_password_rule: rhel9cis_rule_5_3_4  # pragma: allowlist secret
 
 - name: Ensure root password is set
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
             msg: "No local account found for {{ ansible_env.SUDO_USER }} user. Skipping local account checks."
         when:
             - rhel9cis_ansible_user_password_set.stdout == "not found"
+
       - name: "Check local account"
         block:
             - name: "Check password set for {{ ansible_env.SUDO_USER }} | Assert local password set"
@@ -43,6 +44,7 @@
                       - rhel9cis_ansible_user_password_set.stdout != "!!"
                   fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
                   success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user"
+
             - name: "Check account is not locked for {{ ansible_env.SUDO_USER }} | Assert local account not locked"
               ansible.builtin.assert:
                   that:

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -230,7 +230,7 @@
             warn_control_id: '6.1.11'
         when: rhel_09_6_1_11_ungrouped_files_found
   vars:
-      - rhel_09_6_1_11_ungrouped_files_found: false
+      rhel_09_6_1_11_ungrouped_files_found: false
   when:
       - rhel9cis_rule_6_1_11
   tags:


### PR DESCRIPTION
# Overall Review
tasks/main.yml was altered to handle the user not being found in ***/etc/shadow***.  
The ***grep*** has been changed.  

>`(grep {{ ansible_env.SUDO_USER }} /etc/shadow || echo 'not found:not found') | awk -F: '{print $2}'`

In the event that the user is not found in ***/etc/shadow*** then the response ***"not found:not found"*** is given. This is then picked up by the following block to skip the password checking. A debug message is used to alert the user that this is happening.  

An additional check is now being made for local accounts to check that the account has not been locked. This is achieved by checking for a single ***"!"*** at the beginning of the password hash.  

Also updated dictionary in 6.1.11 to convert vars to dictionary to avoid deprecation warning.

# Issue Fixes:
Fixes #176: Using an AD account to connect to host incorrectly fails rule 5.3.4  

# Enhancements:
Fixes #168 DEPRECATION WARNING is generating when play task 6.1.11 | AUDIT | Ensure no ungrouped files or directories exist

# How has this been tested?:
Tested against a minimally configured Alma Linux 9 VM.  
1. Created a new user with an unset password.
	* Local account check passes. Unset password is then detected and play fails.
2. Add a password to new user.
	* Local account check passes. Password check then passes and play continues.
3. Lock the account. Password hash now starts with ***"!"***
	* Second password check is triggered and play fails.
4. Updated VM to join AD realm. Use AD account.
	* The first local account check returns not found. Local password checks are skipped and play continues.

Addendum:
6.1.11 Deprecation warning during audit. Updated vars to dictionary and deprecation warning avoided.

More details on testing are available if required.
