### PR TITLE
Raw cherry-pick of commits: d53e3ed350114e094322162a7984010214acb7e4 …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -998,11 +998,11 @@ rhel9cis_sshd:
     # This variable sets the maximum number of unresponsive "keep-alive" messages
     # that can be sent from the server to the client before the connection is considered
     # inactive and thus, closed.
-    clientalivecountmax: 0
+    clientalivecountmax: 3
     # This variable sets the time interval in seconds between sending "keep-alive"
     # messages from the server to the client. These types of messages are intended to
     # keep the connection alive and prevent it being terminated due to inactivity.
-    clientaliveinterval: 900
+    clientaliveinterval: 15
     # This variable specifies the amount of seconds allowed for successful authentication to
     # the SSH server.
     logingracetime: 60


### PR DESCRIPTION
**Overall Review of Changes:**
Recreation of [this PR](https://github.com/ansible-lockdown/RHEL9-CIS/pull/171) as DCO fails when re-basing.
Basically, it emulates a cherry pick of the two previous commits.

**Issue Fixes:**
#170 

**Enhancements:**
CountAliveCountMax:                   0 -> 3
ClientAliveInterval:                    900 - > 15                                                        # (as agreed on the initial PR with @uk-bolly)

**How has this been tested?:**
N/A

