### PR TITLE
Cleaning up references for authconfig in this repo as well, syntax-er…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1055,10 +1055,6 @@ rhel9cis_inactivelock:
     # This variable specifies the number of days of inactivity before an account will be locked.
     # CIS requires a value of 30 days or less.
     lock_days: 30
-# This variable governs if authconfig package should be installed. This package provides a simple method of
-# configuring /etc/sysconfig/network to handle NIS, as well as /etc/passwd and /etc/shadow, the files used
-# for shadow password support. Basic LDAP, Kerberos 5, and Winbind client configuration is also provided.
-rhel9cis_use_authconfig: false
 
 ## Section 5.4 - Configure authselect: Custom authselect profile settings(name, profile to customize, options)
 ## Controls:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -201,7 +201,6 @@
       - level1_server
       - level1_workstation
 
-
 - name: "PRELIM | 5.3.4 | Find all sudoers files."
   ansible.builtin.shell: "find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'"
   changed_when: false

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -201,26 +201,6 @@
       - level1_server
       - level1_workstation
 
-- name: "PRELIM | Install authconfig"
-  ansible.builtin.package:
-      name: authconfig
-      state: present
-  become: true
-  when:
-      - rhel9cis_use_authconfig
-      - rhel9cis_rule_5_3_1 or
-        rhel9cis_rule_5_3_2 or
-        rhel9cis_rule_5_3_3 or
-       '"authconfig" not in ansible_facts.packages or
-       "auditd-lib" not in ansible_facts.packages'
-  tags:
-      - level1-server
-      - level1-workstation
-      - rule_5.3.1 or
-        rule_5.3.2 or
-        rule_5.3.3
-      - authconfig
-      - auditd
 
 - name: "PRELIM | 5.3.4 | Find all sudoers files."
   ansible.builtin.shell: "find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'"


### PR DESCRIPTION
Removing authconfig, as done in AL2023 by @DianaMariaDDM.

**Overall Review of Changes:**
Authconfig got replaced by Authselect: un-needed prelim task 

**How has this been tested?:**
N/A

