### PR TITLE
Gpg import for rhel servers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changes to rhel9CIS
 
+## 1.1.4 - Based on CIS v1.0.0
+
+- 1.2.1 new option for a new system to import gpg key for 1.2.1 to pass redhat only
+
 ## 1.1.3 - Based on CIS v1.0.0
 
 - updated goss binary to 0.4.4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -424,6 +424,11 @@ rhel9cis_rule_6_2_16: true
 # These /tmp settings will include nosuid,nodev,noexec to conform to CIS standards.
 rhel9cis_tmp_svc: false
 
+## Control 1.2.1
+# For new systems that have not yet run update the gpg key is not yet imported
+# Setting to `true` will allow a test on the package and the foce the import of the key
+rhel9cis_force_gpg_key_import: true
+
 ## Control 1.2.4
 # When installing RHEL from authorized Red Hat source, RHEL will come with default YUM repository. NOT having a default YUM
 # repo ('rhel9cis_rhel_default_repo' set as 'false'), in conjunction with 'rhel9cis_rule_enable_repogpg' set as 'True', will enable the tasks

--- a/tasks/LE_audit_setup.yml
+++ b/tasks/LE_audit_setup.yml
@@ -5,12 +5,12 @@
       - name: Pre Audit Setup | Set audit package name | 64bit
         ansible.builtin.set_fact:
             audit_pkg_arch_name: AMD64
-        when: ansible_machine == "x86_64"
+        when: ansible_facts.machine == "x86_64"
 
       - name: Pre Audit Setup | Set audit package name | ARM64
         ansible.builtin.set_fact:
             audit_pkg_arch_name: ARM64
-        when: ansible_machine == "arm64"
+        when: ansible_facts.machine == "arm64"
 
 - name: Pre Audit Setup | Download audit binary
   ansible.builtin.get_url:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -136,6 +136,31 @@
       - ansible_facts.distribution != 'RedHat'
       - ansible_facts.distribution != 'OracleLinux'
 
+- name: "PRELIM | Check gpg keys are imported will cause 1.2.1 to fail if not | RedHat Only"
+  block:
+      - name: "PRELIM | Check gpg keys are imported will cause 1.2.1 to fail if not"
+        ansible.builtin.shell: rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n'
+        changed_when: false
+        failed_when: false
+        register: check_gpg_imported
+
+      - name: "PRELIM | Check key package matches RedHat"
+        ansible.builtin.shell: rpm -qi redhat-release | grep Signature
+        changed_when: false
+        failed_when: false
+        register: os_gpg_package_valid
+        when: "'not installed' in check_gpg_imported.stdout"
+
+      - name: "PRELIM | Force keys to be imported"
+        ansible.builtin.shell: rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+        when:
+            - "'not installed' in check_gpg_imported.stdout"
+            - "'Key ID 199e2f91fd431d51' in os_gpg_package_valid.stdout"
+  when:
+      - rhel9cis_rule_1_2_1
+      - rhel9cis_force_gpg_key_import
+      - ansible_facts.distribution == 'RedHat'
+
 - name: "PRELIM | Section 4.1 | Configure System Accounting (auditd)"
   ansible.builtin.package:
       name: audit

--- a/tasks/section_4/cis_4.1.4.x.yml
+++ b/tasks/section_4/cis_4.1.4.x.yml
@@ -65,7 +65,7 @@
   ansible.builtin.file:
       path: "{{ item.path }}"
       mode: "{{ '0600' if item.mode == '0600' else '0640' }}"
-  loop: "{{ auditd_conf_files.files | default([]) }}"
+  loop: "{{ auditd_conf_files.files }}"
   loop_control:
       label: "{{ item.path }}"
   when:


### PR DESCRIPTION
**Overall Review of Changes:**
Section 1.2.1 will fail on new rhel system as gpg key not yet imported

**Enhancements:**
- new option by setting to false will check package signature and import key if not imported
  - rhel9cis_force_gpg_key_import: 

**How has this been tested?:**
Manually

