### PR TITLE
Address issues in 4.1.1.2 and 4.1.1.3 including idempotent status

### DIFF
--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -31,10 +31,6 @@
         check_mode: false
         register: rhel9cis_4_1_1_2_grubby_curr_value_audit_linux
 
-      - name: Show list
-        ansible.builtin.debug:
-            msg: "var: \n{{ rhel9cis_4_1_1_2_grubby_curr_value_audit_linux }}"
-
       - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby update, if needed"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="audit=1"
         when:
@@ -74,10 +70,6 @@
         when:
             - (item | int < rhel9cis_audit_back_log_limit)
         loop: "{{ rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux.stdout_lines }}"
-
-      - name: Show list
-        ansible.builtin.debug:
-            msg: "var: \n{{ rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux }}\ntrigger reset: {{ rhel9cis_4_1_1_3_reset_backlog_limits | default(false)}}"
 
       - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby update applied"
         ansible.builtin.shell:

--- a/tasks/section_4/cis_4.1.1.x.yml
+++ b/tasks/section_4/cis_4.1.1.x.yml
@@ -25,16 +25,22 @@
 - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
   block:
       - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby existence of current value"
-        ansible.builtin.shell: grubby --info=ALL | grep args | grep -o -E "audit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"
+        ansible.builtin.shell: grubby --info=ALL | grep args | sed -n 's/.*audit=\([[:alnum:]]\+\).*/\1/p'
         changed_when: false
         failed_when: false
         check_mode: false
         register: rhel9cis_4_1_1_2_grubby_curr_value_audit_linux
 
+      - name: Show list
+        ansible.builtin.debug:
+            msg: "var: \n{{ rhel9cis_4_1_1_2_grubby_curr_value_audit_linux }}"
+
       - name: "4.1.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled | Grubby update, if needed"
         ansible.builtin.shell: grubby --update-kernel=ALL --args="audit=1"
         when:
-            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux | int != 1
+            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout == '' or
+              '0' in rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout or
+              'off' in rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout|lower
   when:
       - rhel9cis_rule_4_1_1_2
   tags:
@@ -48,16 +54,36 @@
 - name: "4.1.1.3 | PATCH | Ensure audit_backlog_limit is sufficient"
   block:
       - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby existence of current value"
-        ansible.builtin.shell: grubby --info=ALL | grep args | grep -o -E "audit_backlog_limit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"
+        ansible.builtin.shell:
+            cmd: 'grubby --info=ALL | grep args | grep -o -E "audit_backlog_limit=([[:digit:]])+" | grep -o -E "([[:digit:]])+"'
         changed_when: false
         failed_when: false
         check_mode: false
         register: rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux
 
-      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby update, if needed"
-        ansible.builtin.shell: grubby --update-kernel=ALL --args="audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"
+      - name: "4.1.1.3 | AUDIT | Check to see if limits are set"
+        ansible.builtin.set_fact:
+            rhel9cis_4_1_1_3_reset_backlog_limits: true
         when:
-            - rhel9cis_4_1_1_2_grubby_curr_value_audit_linux is not defined or rhel9cis_4_1_1_2_grubby_curr_value_audit_linux.stdout | int < rhel9cis_audit_back_log_limit
+            - rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux is not defined or
+              rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux.stdout_lines == []
+
+      - name: "4.1.1.3 | AUDIT | Check to see if any limits are too low"
+        ansible.builtin.set_fact:
+            rhel9cis_4_1_1_3_reset_backlog_limits: true
+        when:
+            - (item | int < rhel9cis_audit_back_log_limit)
+        loop: "{{ rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux.stdout_lines }}"
+
+      - name: Show list
+        ansible.builtin.debug:
+            msg: "var: \n{{ rhel9cis_4_1_1_3_grubby_curr_value_backlog_linux }}\ntrigger reset: {{ rhel9cis_4_1_1_3_reset_backlog_limits | default(false)}}"
+
+      - name: "4.1.1.3 | AUDIT | Ensure audit_backlog_limit is sufficient | Grubby update applied"
+        ansible.builtin.shell:
+            cmd: 'grubby --update-kernel=ALL --args="audit_backlog_limit={{ rhel9cis_audit_back_log_limit }}"'
+        when:
+            - rhel9cis_4_1_1_3_reset_backlog_limits is defined
   when:
       - rhel9cis_rule_4_1_1_3
   tags:


### PR DESCRIPTION
# Overall Review
4.1.1.2 and 4.1.1.3 Do not accurately determine the current state of the Kernel audit and audit backlog limits. As such they always trigger, spoiling idempotency.

# Issue Fixes:
Fixes #187: Idempotent and other issues in 4.1.1.2 and 4.1.1.3  
Fixes #160

# Enhancements:
None other than the fixes identified

# How has this been tested?:
Tested against a minimally configured Alma Linux 9 VM.
## audit task 4.1.1.2
1. Ran numerous combinations of 1 and 0 and Off (in various case upper/lower/mixed)  
   * Correctly identified when it needed to run and when not  
2. Ran against a single kernel, so a single response from grubby
   * Correctly identified when it needed to run and when not  
3. Ran against multiple kernels, so an array response from grubby
   * Correctly identified when it needed to run and when not  
4. Ran test against none of the kernels having the arg set   
   * Correctly identified that it needed to run
5. Repeated runs do not trigger grubby to update
   * Correctly identified that it did not need to run
## audit backlog limit task 4.1.1.3
1. Ran numerous combinations of different elements in the array being below the target
   * Correctly identified when it needed to run and when not  
2. Ran against a single kernel, so a single response from grubby
   * Correctly identified when it needed to run and when not  
3. Ran against multiple kernels, so an array response from grubby
   * Correctly identified when it needed to run and when not  
4. Ran test against none of the kernels having the arg set   
   * Correctly identified that it needed to run   
5. Repeated runs do not trigger grubby to update
   * Correctly identified that it did not need to run
