### PR TITLE
removing the async; the results of init are needed in the subsequent step

### DIFF
--- a/tasks/section_1/cis_1.3.x.yml
+++ b/tasks/section_1/cis_1.3.x.yml
@@ -9,10 +9,6 @@
 
       - name: "1.3.1 | PATCH | Ensure AIDE is installed | Build AIDE DB"
         ansible.builtin.shell: /usr/sbin/aide --init
-        changed_when: false
-        failed_when: false
-        async: 45
-        poll: 0
         args:
             creates: /var/lib/aide/aide.db.new.gz
         when: not ansible_check_mode


### PR DESCRIPTION
**Overall Review of Changes:**
Removing async because the results of the `aide --init` are required in the subsequent step

**Issue Fixes:**
https://github.com/ansible-lockdown/RHEL9-CIS/issues/197

**Enhancements:**
none

**How has this been tested?:**
I provisioned a VM using a template and this code.

