### PR TITLE
2.4 : socket vs sockets (typo)

### DIFF
--- a/tasks/section_2/cis_2.4.yml
+++ b/tasks/section_2/cis_2.4.yml
@@ -10,7 +10,7 @@
         register: rhel9cis_2_4_services
 
       - name: "2.4 | AUDIT | Ensure nonessential services listening on the system are removed or masked | Get list of sockets"
-        ansible.builtin.shell: systemctl list-units --type=sockets
+        ansible.builtin.shell: systemctl list-units --type=socket
         changed_when: false
         failed_when: false
         check_mode: false


### PR DESCRIPTION
**Overall Review of Changes:**
This looks for all active sockets, but the command is singular

**Issue Fixes:**
-

**Enhancements:**
-

**How has this been tested?:**
Manually the command : 

```
[root@ducky svennd]# systemctl list-units --type=sockets
Unknown unit type or load state 'sockets'.
Use -t help to see a list of allowed values.

[root@ducky svennd]# systemctl list-units --type=socket
  UNIT                            LOAD   ACTIVE SUB       DESCRIPTION
  dbus.socket                     loaded active running   D-Bus System Message Bus Socket
  dm-event.socket                 loaded active listening Device-mapper event daemon FIFOs
  lvm2-lvmpolld.socket            loaded active listening LVM2 poll daemon socket
  sssd-kcm.socket                 loaded active listening SSSD Kerberos Cache Manager responder socket
  systemd-coredump.socket         loaded active listening Process Core Dump Socket
  systemd-initctl.socket          loaded active listening initctl Compatibility Named Pipe
  systemd-journald-dev-log.socket loaded active running   Journal Socket (/dev/log)
  systemd-journald.socket         loaded active running   Journal Socket
  systemd-rfkill.socket           loaded active listening Load/Save RF Kill Switch Status /dev/rfkill Watch
  systemd-udevd-control.socket    loaded active running   udev Control Socket
  systemd-udevd-kernel.socket     loaded active running   udev Kernel Socket

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.
11 loaded units listed. Pass --all to see loaded but inactive units, too.
To show all installed unit files use 'systemctl list-unit-files'.
```
