### PR TITLE
removed skip_ansible_lint tag

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -57,8 +57,6 @@
 - name: Grub2cfg
   ansible.builtin.shell: "grub2-mkconfig -o /boot/grub2/grub.cfg"
   ignore_errors: true  # noqa ignore-errors
-  tags:
-      - skip_ansible_lint
 
 - name: Restart rsyslog
   ansible.builtin.systemd:
@@ -102,8 +100,6 @@
 
 - name: Restart auditd
   ansible.builtin.shell: service auditd restart
-  tags:
-      - skip_ansible_lint
 
 - name: Change_requires_reboot
   ansible.builtin.set_fact:

--- a/tasks/section_1/cis_1.1.3.x.yml
+++ b/tasks/section_1/cis_1.1.3.x.yml
@@ -45,6 +45,5 @@
       - level1-workstation
       - patch
       - mounts
-      - skip_ansible_lint
       - rule_1.1.3.2
       - rule_1.1.3.3

--- a/tasks/section_1/cis_1.1.4.x.yml
+++ b/tasks/section_1/cis_1.1.4.x.yml
@@ -48,7 +48,6 @@
       - level1-workstation
       - patch
       - mounts
-      - skip_ansible_lint
       - rule_1.1.4.2
       - rule_1.1.4.3
       - rule_1.1.4.4

--- a/tasks/section_1/cis_1.1.5.x.yml
+++ b/tasks/section_1/cis_1.1.5.x.yml
@@ -22,7 +22,6 @@
       - audit
       - mounts
       - rule_1.1.5.1
-      - skip_ansible_lint
 
 - name: |
           "1.1.5.2 | PATCH | Ensure nodev option set on /var/log partition"
@@ -48,7 +47,6 @@
       - level1-workstation
       - patch
       - mounts
-      - skip_ansible_lint
       - rule_1.1.5.2
       - rule_1.1.5.3
       - rule_1.1.5.4

--- a/tasks/section_1/cis_1.1.6.x.yml
+++ b/tasks/section_1/cis_1.1.6.x.yml
@@ -47,7 +47,6 @@
       - level1-workstation
       - patch
       - mounts
-      - skip_ansible_lint
       - rule_1.1.6.2
       - rule_1.1.6.3
       - rule_1.1.6.4

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -22,7 +22,6 @@
       - audit
       - mounts
       - rule_1.1.7.1
-      - skip_ansible_lint
 
 - name: |
     "1.1.7.2 | PATCH | Ensure nodev option set on /home partition
@@ -48,4 +47,3 @@
       - mounts
       - rule_1.1.7.2
       - rule_1.1.7.3
-      - skip_ansible_lint

--- a/tasks/section_1/cis_1.1.8.x.yml
+++ b/tasks/section_1/cis_1.1.8.x.yml
@@ -29,7 +29,6 @@
       - audit
       - mounts
       - rule_1.1.8.1
-      - skip_ansible_lint
 
 - name: |
        "1.1.8.2 | PATCH | Ensure nodev option set on /dev/shm partition | Set nodev option

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -85,7 +85,6 @@
       - manual
       - audit
       - rule_1.2.3
-      - skip_ansible_lint
 
 - name: "1.2.4 | AUDIT | Ensure repo_gpgcheck is globally activated"
   block:

--- a/tasks/section_1/cis_1.9.yml
+++ b/tasks/section_1/cis_1.9.yml
@@ -7,10 +7,8 @@
   notify: Change_requires_reboot
   when:
       - rhel9cis_rule_1_9
-      - not system_is_ec2
   tags:
       - level1-server
       - level1-workstation
       - patch
       - rule_1.9
-      - skip_ansible_lint


### PR DESCRIPTION
**Overall Review of Changes:**
removed skip_ansible_Lint from tags
removed ec2 conditional from 1.9 patching

**How has this been tested?:**
Tested on pipeline (https://github.com/ansible-lockdown/RHEL9-CIS/actions/runs/11914716903) and locally

