### PR TITLE
change way of restarting auditd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -99,7 +99,9 @@
       - auditd_immutable_check.stdout == '1'
 
 - name: Restart auditd
-  ansible.builtin.shell: service auditd restart
+  ansible.builtin.systemd:
+      name: auditd
+      state: restarted
 
 - name: Change_requires_reboot
   ansible.builtin.set_fact:


### PR DESCRIPTION
**Overall Review of Changes:**
Auditd restart is using builtin.shell : service restart auditd , in alma linux 9.5 , service is no longer used so it is better to use builtin.systemd with state restarted, as is being used for other components

**Issue Fixes:**
Fixes issues of running the role on Alma Linux 9.5 instances where the service command is not found

**How has this been tested?:**
N/A
