### PR TITLE
use find instead of fileglob to search for files on remote machine

### DIFF
--- a/tasks/section_5/cis_5.3.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.3.2.x.yml
@@ -10,6 +10,16 @@
     - NIST800-53R5_IA-5
     - pam
   block:
+    - name: "5.3.3.2.1 | PATCH | Ensure password number of changed characters is configured | Find conf files"
+      when: rhel9cis_disruption_high
+      ansible.builtin.shell: |
+        find "/etc/security/pwquality.conf"
+        find "/etc/security/pwquality.conf.d/*.conf"
+        find "/etc/pam.d/*-auth"
+      changed_when: false
+      failed_when: false
+      register: discovered_conf_files
+
     - name: "5.3.3.2.1 | PATCH | Ensure password number of changed characters is configured | Remove difok from conf files except expected file"
       when:
         - item != rhel9cis_passwd_difok_file
@@ -18,10 +28,7 @@
         path: "{{ item }}"
         regexp: 'difok\s*=\s*\d+\b'
         replace: ''
-      with_fileglob:
-        - '/etc/security/pwquality.conf'
-        - '/etc/security/pwquality.conf.d/*.conf'
-        - /etc/pam.d/*-auth
+      loop: "{{ discovered_conf_files.stdout_lines | default([]) }}"
 
     - name: "5.3.3.2.1 | PATCH | Ensure password number of changed characters is configured | Ensure difok file exists"
       ansible.builtin.template:
@@ -66,6 +73,16 @@
     - NIST800-53R5_IA-5
     - pam
   block:
+    - name: "5.3.3.2.2 | PATCH | Ensure minimum password length is configured | Find conf files"
+      when: rhel9cis_disruption_high
+      ansible.builtin.shell: |
+        find "/etc/security/pwquality.conf"
+        find "/etc/security/pwquality.conf.d/*.conf"
+        find "/etc/pam.d/*-auth"
+      changed_when: false
+      failed_when: false
+      register: discovered_conf_files
+
     - name: "5.3.3.2.2 | PATCH | Ensure minimum password length is configured | Remove minlen from conf files except expected file"
       when:
         - item != rhel9cis_passwd_minlen_file
@@ -74,10 +91,7 @@
         path: "{{ item }}"
         regexp: 'minlen\s*=\s*\d+\b'
         replace: ''
-      with_fileglob:
-        - '/etc/security/pwquality.conf'
-        - '/etc/security/pwquality.conf.d/*.conf'
-        - '/etc/pam.d/*-auth'
+      loop: "{{ discovered_conf_files.stdout_lines | default([]) }}"
 
     - name: "5.3.3.2.2 | PATCH | Ensure minimum password length is configured | Ensure minlen file exists"
       ansible.builtin.template:
@@ -122,6 +136,16 @@
     - NIST800-53R5_IA-5
     - pam
   block:
+    - name: "5.3.3.2.3 | PATCH | Ensure password complexity is configured | Find conf files"
+      when: rhel9cis_disruption_high
+      ansible.builtin.shell: |
+        find "/etc/security/pwquality.conf"
+        find "/etc/security/pwquality.conf.d/*.conf"
+        find "/etc/pam.d/*-auth"
+      changed_when: false
+      failed_when: false
+      register: discovered_conf_files
+
     - name: "5.3.3.2.3 | PATCH | Ensure password complexity is configured | Remove pwd complex settings from conf files except expected file"
       when:
         - item != rhel9cis_passwd_complex_file
@@ -130,10 +154,7 @@
         path: "{{ item }}"
         regexp: '(minclass|[dulo]credit)\s*=\s*(-\d|\d+)\b'
         replace: ''
-      with_fileglob:
-        - '/etc/security/pwquality.conf'
-        - '/etc/security/pwquality.conf.d/*.conf'
-        - '/etc/pam.d/*-auth'
+      loop: "{{ discovered_conf_files.stdout_lines | default([]) }}"
 
     - name: "5.3.3.2.3 | PATCH | Ensure password complexity is configured | Ensure complexity file exists"
       ansible.builtin.template:
@@ -178,16 +199,22 @@
     - NIST800-53R5_IA-5
     - pam
   block:
+    - name: "5.3.3.2.4 | PATCH | Ensure password same consecutive characters is configured | Find conf files"
+      ansible.builtin.shell: |
+        find "/etc/security/pwquality.conf"
+        find "/etc/security/pwquality.conf.d/*.conf"
+        find "/etc/pam.d/*-auth"
+      changed_when: false
+      failed_when: false
+      register: discovered_conf_files
+
     - name: "5.3.3.2.4 | PATCH | Ensure password same consecutive characters is configured | Remove maxrepeat settings from conf files except expected file"
       when: item != rhel9cis_passwd_maxrepeat_file
       ansible.builtin.replace:
         path: "{{ item }}"
         regexp: 'maxrepeat\s*=\s*\d+\b'
         replace: ''
-      with_fileglob:
-        - '/etc/security/pwquality.conf'
-        - '/etc/security/pwquality.conf.d/*.conf'
-        - '/etc/pam.d/*-auth'
+      loop: "{{ discovered_conf_files.stdout_lines | default([]) }}"
 
     - name: "5.3.3.2.4 | PATCH | Ensure password same consecutive characters is configured | Ensure maxrepeat file exists"
       ansible.builtin.template:
@@ -232,6 +259,16 @@
     - NIST800-53R5_IA-5
     - pam
   block:
+    - name: "5.3.3.2.5 | PATCH | Ensure password maximum sequential characters is configured | Find conf files"
+      when: rhel9cis_disruption_high
+      ansible.builtin.shell: |
+        find "/etc/security/pwquality.conf"
+        find "/etc/security/pwquality.conf.d/*.conf"
+        find "/etc/pam.d/*-auth"
+      changed_when: false
+      failed_when: false
+      register: discovered_conf_files
+
     - name: "5.3.3.2.5 | PATCH | Ensure password maximum sequential characters is configured | Remove maxsequence settings from conf files except expected file"
       when:
         - item != rhel9cis_passwd_maxsequence_file
@@ -240,10 +277,7 @@
         path: "{{ item }}"
         regexp: 'maxsequence\s*=\s*\d+\b'
         replace: ''
-      with_fileglob:
-        - '/etc/security/pwquality.conf'
-        - '/etc/security/pwquality.conf.d/*.conf'
-        - '/etc/pam.d/*-auth'
+      loop: "{{ discovered_conf_files.stdout_lines | default([]) }}"
 
     - name: "5.3.3.2.5 | PATCH | Ensure password maximum sequential characters is configured | Ensure maxsequence file exists"
       ansible.builtin.template:
@@ -288,6 +322,15 @@
     - NIST800-53R5_IA-5
     - pam
   block:
+    - name: "5.3.3.2.6 | PATCH | Ensure password dictionary check is enabled | Find conf files"
+      ansible.builtin.shell: |
+        find "/etc/security/pwquality.conf"
+        find "/etc/security/pwquality.conf.d/*.conf"
+        find "/etc/pam.d/*-auth"
+      changed_when: false
+      failed_when: false
+      register: discovered_conf_files
+
     - name: "5.3.3.2.6 | PATCH | Ensure password dictionary check is enabled | Remove dictcheck settings from conf files except expected file"
       when:
         - item != rhel9cis_passwd_dictcheck_file
@@ -295,10 +338,7 @@
         path: "{{ item }}"
         regexp: 'dictcheck\s*=\s*\d+\b'
         replace: ''
-      with_fileglob:
-        - '/etc/security/pwquality.conf'
-        - '/etc/security/pwquality.conf.d/*.conf'
-        - '/etc/pam.d/*-auth'
+      loop: "{{ discovered_conf_files.stdout_lines | default([]) }}"
 
     - name: "5.3.3.2.6 | PATCH | Ensure password dictionary check is enabled | Ensure dictcheck file exists"
       ansible.builtin.template:


### PR DESCRIPTION
**Overall Review of Changes:**
Change from using fileglob to using find

**Enhancements:**
fileglob (and any other lookups) use the control machine to retrieve the correct values. If the remote (target) machine has a different set of files, without this change some files may be missed or the command may fail if they exist on the control machine but not the remote one.

**How has this been tested?:**
Manually by running hardening and audit and verifying passing and correct files



