### PR TITLE
Use shell for grep with shell expansions

### DIFF
--- a/tasks/section_5/cis_5.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.2.x.yml
@@ -141,7 +141,7 @@
     - rule_5.3.2.5
   block:
     - name: "5.3.2.5 | AUDIT | Ensure pam_unix module is enabled"
-      ansible.builtin.command: grep -P -- '\b(pam_unix\.so)\b' /etc/authselect/"$(head -1 /etc/authselect/authselect.conf)"/{system,password}-auth
+      ansible.builtin.shell: grep -P -- '\b(pam_unix\.so)\b' /etc/authselect/"$(head -1 /etc/authselect/authselect.conf)"/{system,password}-auth
       changed_when: false
       failed_when: discovered_discovered_authselect_pam_unix.rc not in [ 0, 1 ]
       register: discovered_discovered_authselect_pam_unix


### PR DESCRIPTION
**Overall Review of Changes:**
Use shell for pam_unix module check

**Enhancements:**
the command task doesn't allow for bash expansion (like the `$(`), so switch to using shell

**How has this been tested?:**
Manually, it failed before this change and worked after

