### PR TITLE
Bug/systemd reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -236,7 +236,7 @@
     name: systemd-journal-upload
     state: restarted
 
-- name: Systemd daemon reload
+- name: Systemd_daemon_reload
   ansible.builtin.systemd:
     daemon-reload: true
 

--- a/tasks/section_1/cis_1.5.x.yml
+++ b/tasks/section_1/cis_1.5.x.yml
@@ -63,4 +63,4 @@
     path: /etc/systemd/coredump.conf
     regexp: '^Storage\s*=\s*(?!none).*'
     line: 'Storage=none'
-  notify: Systemd daemon reload
+  notify: Systemd_daemon_reload


### PR DESCRIPTION
**Overall Review of Changes:**
This change changes a single notify to handler `Systemd daemon reload` to `Systemd_daemon_reload` and changes the handler name accordingly. All other notifications to this handler already use the new name.

**Issue Fixes:**
[Handler naming mismatch #309](https://github.com/ansible-lockdown/RHEL9-CIS/issues/309)

**Enhancements:**
N/A

**How has this been tested?:**
N/A

