### PR TITLE
Fix typo in variable name discovered_group_check

### DIFF
--- a/tasks/section_7/cis_7.2.x.yml
+++ b/tasks/section_7/cis_7.2.x.yml
@@ -220,7 +220,7 @@
     - name: "7.2.7 | AUDIT | Ensure no duplicate group names exist | Print warning about users with duplicate group names"
       when: discovered_group_check.stdout | length > 0
       ansible.builtin.debug:
-        msg: "Warning!! The following group names are duplicates: {{ discovered_group_group_check.stdout_lines }}"
+        msg: "Warning!! The following group names are duplicates: {{ discovered_group_check.stdout_lines }}"
 
     - name: "7.2.7 | AUDIT | Ensure no duplicate group names exist | Set warning count"
       when: discovered_group_check.stdout | length > 0


### PR DESCRIPTION
`discovered_group_group_check` is a typo, should be `discovered_group_check`