### PR TITLE
Check for existence of sshd_config.d/50-redhat.conf

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -246,6 +246,14 @@
     mode: 'go-rwx'
     state: touch
 
+- name: "PRELIM | PATCH | sshd_config.d/50-redhat.conf exists"
+  when:
+    - rhel9cis_rule_5_1_10 or
+      rhel9cis_rule_5_1_11
+  ansible.builtin.stat:
+    path: /etc/ssh/sshd_config.d/50-redhat.conf
+  register: discovered_sshd_50_redhat_file
+
 - name: "PRELIM | AUDIT | Capture pam security related files"
   tags: always
   ansible.builtin.find:

--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -276,6 +276,7 @@
       notify: Restart sshd
 
     - name: "5.1.10 | PATCH | Ensure sshd DisableForwarding is enabled | override"
+      when: discovered_sshd_50_redhat_file.stat.exists
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config.d/50-redhat.conf
         regexp: ^(?i)(#|)\s*X11Forwarding
@@ -298,6 +299,7 @@
     - NIST800-53R5_IA-5
   block:
     - name: "5.1.11 | PATCH | Ensure sshd GSSAPIAuthentication is disabled | redhat file"
+      when: discovered_sshd_50_redhat_file.stat.exists
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config.d/50-redhat.conf
         regexp: ^(?i)(#|)\s*GSSAPIAuthentication


### PR DESCRIPTION
An operator could have removed **/etc/ssh/sshd_config.d/50-redhat.conf**. The CIS lockdown should not fail if this file is absent.