### PR TITLE
fix typo's and copy paste errors

### DIFF
--- a/tasks/section_1/cis_1.1.2.3.x.yml
+++ b/tasks/section_1/cis_1.1.2.3.x.yml
@@ -21,12 +21,12 @@
       register: discovered_home_mount
 
     - name: "1.1.2.3.1 | AUDIT | Ensure /home is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount is undefined
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.3.1 | AUDIT | Ensure /home is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_home_mount is undefined
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_1/cis_1.1.2.4.x.yml
+++ b/tasks/section_1/cis_1.1.2.4.x.yml
@@ -22,12 +22,12 @@
       register: discovered_var_mount
 
     - name: "1.1.2.4.1 | AUDIT | Ensure /var is a separate partition | Absent"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_var_mount is undefined
       ansible.builtin.debug:
         msg: "Warning!! {{ required_mount }} is not mounted on a separate partition"
 
     - name: "1.1.2.4.1 | AUDIT | Ensure /var is a separate partition | Present"
-      when: discovered_dev_shm_mount is undefined
+      when: discovered_var_mount is undefined
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 

--- a/tasks/section_7/cis_7.1.x.yml
+++ b/tasks/section_7/cis_7.1.x.yml
@@ -58,7 +58,7 @@
     - level1-server
     - level1-workstation
     - patch
-    - permissionss
+    - permissions
     - rule_7.1.4
     - NIST800-53R5_AC-3
     - NIST800-53R5_MP-2

--- a/tasks/section_7/cis_7.2.x.yml
+++ b/tasks/section_7/cis_7.2.x.yml
@@ -186,7 +186,7 @@
     - name: "7.2.6 | WARNING | Ensure no duplicate user names exist | Print warning about users with duplicate User Names"
       when: discovered_username_check.stdout | length > 0
       ansible.builtin.debug:
-        msg: "Warning!! The following user names are duplicates: {{ discovered_user_username_check.stdout_lines }}"
+        msg: "Warning!! The following user names are duplicates: {{ discovered_username_check.stdout_lines }}"
 
     - name: "7.2.6 | WARNING | Ensure no duplicate user names exist | Set warning count"
       when: discovered_username_check.stdout | length > 0


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

- 1.1.2.3.1 => copy/paste error?
   adjusted so all `when` conditions use registered 'discovered_home_mount' var
- 1.1.2.4.1=> copy/paste error?
   adjusted so all `when` conditions use registered  'discovered_var_mount' var
- 7.1.4 => Fix typo in tag
  removes extra 's' at end of `permissions`
- 7.2.6 => Fixed var name
  fix non-exsisting var to correct registered  var `discovered_username_check.stdout_lines`

**How has this been tested?:**
N/A

