### PR TITLE
prelim_interactive_users must be set in defaults else failure if ther…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,9 @@ skip_reboot: true
 # default value will change to true but wont reboot if not enabled but will error
 change_requires_reboot: false
 
+# list of dicts of interactive users, filled in during prelim.yml
+prelim_interactive_users: []
+
 ###
 ### Settings for associated Audit role using Goss
 ###


### PR DESCRIPTION
**PRELIM | AUDIT | Interactive Users** will return a null string if there are zero interactive users, and then, **PRELIM | AUDIT | Interactive Users (reformat)** will not execute. Subsequent attempts to reference the `prelim_interactive_users` variable will fail the role.