### PR TITLE
update: change insertafter by insertbefore for MISC. LOG SETTINGS

### DIFF
--- a/tasks/section_6/cis_6.2.3.x.yml
+++ b/tasks/section_6/cis_6.2.3.x.yml
@@ -130,8 +130,8 @@
           # misc. logging additions to meet CIS standards
           *.=warning;*.=err                                        -/var/log/warn
           *.crit                                                   /var/log/warn
-          *.*;mail.none;news.none                                  /var/log/messages
-        insertafter: '#### RULES ####'
+          *.*;news.none                                            /var/log/messages
+        insertbefore: '# ### sample forwarding rule ###'
       notify: Restart rsyslog
 
     - name: "6.2.3.5 | PATCH | Ensure logging is configured | Local log settings"


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
To be sure that this section will be placed at the end of facilities configuration, insertafter "RULES" is replaced by inserafter "# ### sample forwarding rule ###"
And mail.none is deleted because mail.* is declared before.

**Issue Fixes:**
(https://github.com/ansible-lockdown/RHEL9-CIS/issues/349)

**How has this been tested?:**
N/A (I wanted to test by molecule but there is an issue with audit package)

