### PR TITLE
Fix re.error due to (?i) not at start of re

### DIFF
--- a/tasks/section_6/cis_6.2.2.x.yml
+++ b/tasks/section_6/cis_6.2.2.x.yml
@@ -50,7 +50,7 @@
     - name: "6.2.2.3 | PATCH | Ensure journald Compress is configured | comment out current entries"
       ansible.builtin.replace:
         path: /etc/systemd/journald.conf
-        regexp: ^(?i)(\s*compress=)
+        regexp: (?i)(\s*compress=)
         replace: '#\1'
 
 - name: "6.2.2.4 | PATCH | Ensure journald Storage is configured"
@@ -76,5 +76,5 @@
     - name: "6.2.2.4 | PATCH | Ensure journald Storage is configured | comment out current entries"
       ansible.builtin.replace:
         path: /etc/systemd/journald.conf
-        regexp: ^(?i)(\s*storage=)
+        regexp: (?i)(\s*storage=)
         replace: '#\1'


### PR DESCRIPTION




Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**

6.2.2.3 and 6.2.2.4 cause issues due to current re syntax: ^(?i)(\s*compress=)

re.error: global flags not at the start of the expression at position 1

Fix removes ^ at start of regex, which resolves issue without affecting functionality.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
Deployed to RHEL 9.4 and RHEL 9.6 servers x 2 and tested, confirmed expected behaviour with no issues.

