### PR TITLE
Add disablement flag for the gdm controls (1.8.x)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -592,6 +592,8 @@ rhel9cis_warning_banner: Authorized users only. All activity may be monitored an
 # End Banner
 
 ## Control 1.8.x - Settings for GDM
+# do not run Control 1.8.x if using a display manager different than gdm
+rhel9cis_display_manager: "gdm"
 ## 1.8 GDM graphical interface
 rhel9cis_gui: "{{ prelim_gnome_present.stat.exists | default(false) }}"
 # This variable specifies the GNOME configuration database file to which configurations are written.

--- a/tasks/section_1/main.yml
+++ b/tasks/section_1/main.yml
@@ -61,5 +61,6 @@
     file: cis_1.7.x.yml
 
 - name: "SECTION | 1.8 | Gnome Display Manager"
+  when: rhel9cis_display_manager == 'gdm'
   ansible.builtin.import_tasks:
     file: cis_1.8.x.yml


### PR DESCRIPTION
Allows operator to optionally disable execution of the entire GDM stanza (ie: if they're using XFCE's lightdm)