### PR TITLE
Fixing pre-check for 5.2.4

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,11 +93,14 @@
       block:
         - name: "Check password set for {{ ansible_env.SUDO_USER }} | Assert local password set"  # noqa name[template]
           ansible.builtin.assert:
-            that:
-              - prelim_ansible_user_password_set.stdout | length != 0
-              - prelim_ansible_user_password_set.stdout != "!!"
+            that: |
+              (
+                ((prelim_ansible_user_password_set.stdout | length != 0) and (prelim_ansible_user_password_set.stdout != "!!" ))
+              or
+                (ansible_env.SUDO_USER in rhel9cis_sudoers_exclude_nopasswd_list)
+              )
             fail_msg: "You have {{ sudo_password_rule }} enabled but the user = {{ ansible_env.SUDO_USER }} has no password set - It can break access"
-            success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user"
+            success_msg: "You have a password set for the {{ ansible_env.SUDO_USER }} user or the user is included in the exception list for rule 5.2.4"
 
         - name: "Check account is not locked for {{ ansible_env.SUDO_USER }} | Assert local account not locked"  # noqa name[template]
           ansible.builtin.assert:


### PR DESCRIPTION
Allow sudo user without password if the user is configured in the exceptions for 5.2.4

**Overall Review of Changes:**

The preliminary check should ideally take rhel9cis_sudoers_exclude_nopasswd_list into account

**Issue Fixes:**

Corresponds to #318, treating the part that has not been fixed yet.

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Tested with local testbed.
