### PR TITLE
renames 3 uses of ansible.builtin.systemd_service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -263,7 +263,7 @@
   listen: Restart auditd
 
 - name: Start auditd process
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: auditd
     state: started
   listen: Restart auditd

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -91,13 +91,13 @@
 
     - name: "6.1.2 | PATCH | Ensure filesystem integrity is regularly checked | aide service"
       when: rhel9cis_aide_scan == "timer"
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: aidecheck.service
         enabled: true
 
     - name: "6.1.2 | PATCH | Ensure filesystem integrity is regularly checked | aide service"
       when: rhel9cis_aide_scan == "timer"
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: aidecheck.timer
         state: started
         enabled: true


### PR DESCRIPTION
**Overall Review of Changes:**
renames 3 uses of `ansible.builtin.systemd_service` to `ansible.builtin.systemd` to maintain ansible 2.12+ compat. 

**Issue Fixes:**
 Fixes #379 

**How has this been tested?:**
Tested against Rocky 9.4 hosts I am managing with this

