### PR TITLE
5.4.1.1: shell command should run in check_mode

### DIFF
--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -24,6 +24,7 @@
       ansible.builtin.shell: "awk -F: '(/^[^:]+:[^!*]/ && ($5> {{ rhel9cis_pass_max_days }} || $5< {{ rhel9cis_pass_max_days }} || $5 == -1)){print $1}' /etc/shadow"
       changed_when: false
       failed_when: false
+      check_mode: false
       register: discovered_max_days
 
     - name: "5.4.1.1 | PATCH | Ensure password expiration is 365 days or less | Set existing users PASS_MAX_DAYS"


### PR DESCRIPTION
Non-volatile shell command should run in check mode.