### PR TITLE
5.3.2.2: fix regex failing to match whitespace

### DIFF
--- a/tasks/section_5/cis_5.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.2.x.yml
@@ -91,9 +91,15 @@
             insertafter: "{{ item.after | default(omit) }}"
             line: "{{ item.line }}"
           loop:
-            - { regexp: auth\s*required\s*pam_faillock.so preauth, after: auth\s*required\s*pam_env.so, line: "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" }
-            - { regexp: auth\s*required\s*pam_faillock.so authfail, before: auth\s*required\s*pam_deny.so, line: "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" }
-            - { regexp: account\s*required\s*pam_faillock.so, before: account\s*required\s*pam_unix.so, line: "account     required      pam_faillock.so" }
+            - regexp: "auth\\s+required\\s+pam_faillock.so\\s+preauth"
+              after:  "auth\\s+required\\s+pam_env.so" # yamllint disable-line rule:colons
+              line:   "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+            - regexp: "auth\\s+required\\s+pam_faillock.so\\s+authfail"
+              before: "auth\\s+required\\s+pam_deny.so"
+              line:   "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+            - regexp: "account\\s+required\\s+pam_faillock.so"
+              before: "account\\s+required\\s+pam_unix.so"
+              line:   "account     required      pam_faillock.so" # yamllint disable-line rule:colons
 
         - name: "5.3.2.2 | AUDIT | Ensure pam_faillock module is enabled | Add lines password-auth"
           when: not rhel9cis_allow_authselect_updates
@@ -104,9 +110,15 @@
             insertafter: "{{ item.after | default(omit) }}"
             line: "{{ item.line }}"
           loop:
-            - { regexp: auth\s*required\s*pam_faillock.so preauth, after: auth\s*required\s*pam_env.so, line: "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" }
-            - { regexp: auth\s*required\s*pam_faillock.so authfail, before: auth\s*required\s*pam_deny.so, line: "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" }
-            - { regexp: account\s*required\s*pam_faillock.so, before: account\s*required\s*pam_unix.so, line: "account     required      pam_faillock.so" }
+            - regexp: "auth\\s+required\\s+pam_faillock.so\\s+preauth"
+              after:  "auth\\s+required\\s+pam_env.so" # yamllint disable-line rule:colons
+              line:   "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+            - regexp: "auth\\s+required\\s+pam_faillock.so\\s+authfail"
+              before: "auth\\s+required\\s+pam_deny.so"
+              line:   "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+            - regexp: "account\\s+required\\s+pam_faillock.so"
+              before: "account\\s+required\\s+pam_unix.so"
+              line:   "account     required      pam_faillock.so" # yamllint disable-line rule:colons
 
 - name: "5.3.2.3 | PATCH | Ensure pam_pwquality module is enabled"
   when:


### PR DESCRIPTION
1) Was matching for `pam_faillock.so preauth`, but previous runs of RHEL9-CIS had more than one space. Subsequent runs of this playbook was creating multiple faillock.so lines in my pam config. This fixed regex to match for any number of whitespace characters.

2) Fixed playbook formatting to be more readable.