### PR TITLE
Suggestion for the missing assert parameter

### DIFF
--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -57,6 +57,7 @@
     - name: Pre Audit Setup | If audit ensure goss is available
       when: not prelim_goss_available.stat.exists
       ansible.builtin.assert:
+        that: prelim_goss_available['stat']['exists'] == true
         msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
 
 - name: Pre Audit Setup | Copy ansible default vars values to test audit


### PR DESCRIPTION
**Describe the Issue**

Hello,

I flipped the `run_audit:` to `true` in `defaults/main.yml` and the playbook failed. It seems the assert is missing the `that:` parameter in `tasks/pre_remediation_audit.yml` line 60.

**Expected Behavior**
Goss is not installed on my system, so I expected a message like:
```
"msg": "Audit has been selected: unable to find goss binary at /usr/local/bin/goss"
```

**Actual Behavior**
```
fatal: [alma9]: FAILED! => {"msg": "conditional required in \"that\" string"}
```

**Environment (please complete the following information):**

- branch being used: devel
- Ansible Version: 2.18.6
- Host Python Version: 3.9.21
- Ansible Server Python Version: 3.12.5

**Possible Solution**
Something like this would throw the correct response:
```
- name: Pre Audit Setup | If audit ensure goss is available
  when: not prelim_goss_available.stat.exists
  ansible.builtin.assert:
	that: prelim_goss_available['stat']['exists'] == true
	msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
```

Result:
```
fatal: [alma9]: FAILED! => {
    "assertion": "prelim_goss_available['stat']['exists'] == true",
    "changed": false,
    "evaluated_to": false,
    "msg": "Audit has been selected: unable to find goss binary at /usr/local/bin/goss"
}
```


