### PR TITLE
Update cis_3.2.x.yml (add dccp to blacklist instead of cramfs

### DIFF
--- a/tasks/section_3/cis_3.2.x.yml
+++ b/tasks/section_3/cis_3.2.x.yml
@@ -25,8 +25,8 @@
     - name: "3.2.1 | PATCH | Ensure dccp kernel module is not available | blacklist"
       ansible.builtin.lineinfile:
         path: /etc/modprobe.d/blacklist.conf
-        regexp: "^(#)?blacklist cramfs(\\s|$)"
-        line: "blacklist cramfs"
+        regexp: "^(#)?blacklist dccp(\\s|$)"
+        line: "blacklist dccp"
         create: true
         mode: 'u-x,go-rwx'
 


### PR DESCRIPTION
**Overall Review of Changes:**
Fix for rule 3.2.1 ("Ensure dccp kernel module is not available") to blacklist dccp instead of cramfs

**Issue Fixes:**
Fixes https://github.com/ansible-lockdown/RHEL9-CIS/issues/397

**Enhancements:**
N/A

**How has this been tested?:**
N/A

