### PR TITLE
Make task flexible by checking if the current file group owner is ssh_key

### DIFF
--- a/tasks/section_5/cis_5.1.x.yml
+++ b/tasks/section_5/cis_5.1.x.yml
@@ -41,8 +41,8 @@
       ansible.builtin.file:
         path: "{{ item.path }}"
         owner: root
-        group: root
-        mode: 'u-x,go-rwx'
+        group: "{{ 'ssh_keys' if (item.group == 'ssh_keys') else 'root' }}"
+        mode: "{{ 'u-x,g-wx,o-rwx' if (item.group == 'ssh_keys') else 'u-x,go-rwx' }}"
       loop: "{{ discovered_ssh_private_host_key.files }}"
       loop_control:
         label: "{{ item.path }}"


### PR DESCRIPTION
**Overall Review of Changes:**
Allow group owner to be both `root` and `ssh_keys` to align with official documentation. Adjust file mode based on this.

**Issue Fixes:**
Fixes https://github.com/ansible-lockdown/RHEL9-CIS/issues/399

**Enhancements:**
N/A

**How has this been tested?:**
N/A

