### PR TITLE
fix: make 5.3.2.2 idempotent with 5.3.3.1.1

### DIFF
--- a/tasks/section_5/cis_5.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.2.x.yml
@@ -93,10 +93,10 @@
           loop:
             - regexp: "auth\\s+required\\s+pam_faillock.so\\s+preauth"
               after:  "auth\\s+required\\s+pam_env.so" # yamllint disable-line rule:colons
-              line:   "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+              line:   "auth        required      pam_faillock.so preauth silent unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
             - regexp: "auth\\s+required\\s+pam_faillock.so\\s+authfail"
               before: "auth\\s+required\\s+pam_deny.so"
-              line:   "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+              line:   "auth        required      pam_faillock.so authfail silent unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
             - regexp: "account\\s+required\\s+pam_faillock.so"
               before: "account\\s+required\\s+pam_unix.so"
               line:   "account     required      pam_faillock.so" # yamllint disable-line rule:colons
@@ -112,10 +112,10 @@
           loop:
             - regexp: "auth\\s+required\\s+pam_faillock.so\\s+preauth"
               after:  "auth\\s+required\\s+pam_env.so" # yamllint disable-line rule:colons
-              line:   "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+              line:   "auth        required      pam_faillock.so preauth silent unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
             - regexp: "auth\\s+required\\s+pam_faillock.so\\s+authfail"
               before: "auth\\s+required\\s+pam_deny.so"
-              line:   "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
+              line:   "auth        required      pam_faillock.so authfail silent unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}" # yamllint disable-line rule:colons
             - regexp: "account\\s+required\\s+pam_faillock.so"
               before: "account\\s+required\\s+pam_unix.so"
               line:   "account     required      pam_faillock.so" # yamllint disable-line rule:colons


### PR DESCRIPTION
**Overall Review of Changes:**

`"5.3.2.2 | PATCH | Ensure pam_faillock module is enabled | Add lines system-auth"` currently add to /etc/pam.d/system-auth :
- line:   "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}"
- line:   "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}"

And `"5.3.2.2 | AUDIT | Ensure pam_faillock module is enabled | Add lines password-auth"` currently add to /etc/pam.d/password-auth :
- line:   "auth        required      pam_faillock.so preauth silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}"
- line:   "auth        required      pam_faillock.so authfail silent deny=3 unlock_timeout={{ rhel9cis_pam_faillock_unlock_time }}"

But `"5.3.3.1.1 | PATCH | Ensure password failed attempts lockout is configured | remove deny from AuthSelect config"` remove `deny=3` from the 4 lines added by 5.3.2.2 rules in /etc/pam.d/system-auth and /etc/pam.d/password-auth.

This change remove `deny=3` from rule 5.3.2.2, so 5.3.2.2 is idempotent with 5.3.2.2.