### PR TITLE
Move rhel9cis_ipv6_disable_method to a better location

### DIFF
--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -206,7 +206,6 @@ rhel9cis_rule_2_4_2_1: {{ rhel9cis_rule_2_4_2_1 }}
 rhel9cis_rule_3_1_1: {{ rhel9cis_rule_3_1_1 }}
 rhel9cis_rule_3_1_2: {{ rhel9cis_rule_3_1_2 }}
 rhel9cis_rule_3_1_3: {{ rhel9cis_rule_3_1_3 }}
-rhel9cis_ipv6_disable_method: {{ rhel9cis_ipv6_disable_method }}
 
 ## Network Kernel Modules
 rhel9cis_rule_3_2_1: {{ rhel9cis_rule_3_2_1 }}
@@ -532,6 +531,8 @@ rhel9cis_bluetooth_mask: {{ rhel9cis_bluetooth_mask }}
 ## 3.1 IPv6 requirement toggle
 # This variable governs whether ipv6 is enabled or disabled.
 rhel9cis_ipv6_required: {{ rhel9cis_ipv6_required }}
+# rhel9cis_ipv6_disable defines the method of disabling IPv6, sysctl vs kernel
+rhel9cis_ipv6_disable_method: {{ rhel9cis_ipv6_disable_method }}
 
 # 3.3 System network parameters (host only OR host and router)
 # This variable governs whether specific CIS rules


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Move rhel9cis_ipv6_disable_method to a better location

**Issue Fixes:**
None

**Enhancements:**
None

**How has this been tested?:**
Tested locally in audit only scenario and found no regression

