### PR TITLE
added guardrails on enabled and state flags to systemd mask tasks

### DIFF
--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -270,7 +270,6 @@
         state: "{{ ('cyrus-imapd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
-
 - name: "2.1.9 | PATCH | Ensure network file system services are not in use"
   when: rhel9cis_rule_2_1_9
   tags:

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -28,8 +28,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: autofs
-        enabled: false
-        state: stopped
+        enabled: "{{ ('autofs' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('autofs' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.2 | PATCH | Ensure avahi daemon services are not in use"
@@ -60,8 +60,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('avahi' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('avahi' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - avahi-daemon.socket
@@ -93,8 +93,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('dhcp-server' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('dhcp-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - dhcpd.service
@@ -126,8 +126,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: named.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('bind' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('bind' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.5 | PATCH | Ensure dnsmasq server services are not in use"
@@ -156,8 +156,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: dnsmasq.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('dnsmasq' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('dnsmasq' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.6 | PATCH | Ensure samba file server services are not in use"
@@ -187,8 +187,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: smb.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('samba' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('samba' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.7 | PATCH | Ensure ftp server services are not in use"
@@ -218,8 +218,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: vsftpd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('vsftpd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('vsftpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.8 | PATCH | Ensure message access server services are not in use"
@@ -245,20 +245,31 @@
           - cyrus-imapd
         state: absent
 
-    - name: "2.1.8 | PATCH | Ensure message access server services are not in use | Mask service"
+    - name: "2.1.8 | PATCH | Ensure message access server services are not in use | Mask service dovecot"
       when:
         - not rhel9cis_message_server
         - rhel9cis_message_mask
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('dovecot' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('dovecot' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - "dovecot.socket"
         - "dovecot.service"
-        - "cyrus-imapd.service"
+
+    - name: "2.1.8 | PATCH | Ensure message access server services are not in use | Mask service cyrus-imapd"
+      when:
+        - not rhel9cis_message_server
+        - rhel9cis_message_mask
+      notify: Systemd daemon reload
+      ansible.builtin.systemd:
+        name: cyrus-imapd.service
+        enabled: "{{ ('cyrus-imapd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('cyrus-imapd' in ansible_facts.packages) | ternary('stopped', omit) }}"
+        masked: true
+
 
 - name: "2.1.9 | PATCH | Ensure network file system services are not in use"
   when: rhel9cis_rule_2_1_9
@@ -288,8 +299,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: nfs-server.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('nfs-utils' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('nfs-utils' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.10 | PATCH | Ensure nis server services are not in use"
@@ -318,8 +329,8 @@
         - rhel9cis_nis_mask
       ansible.builtin.systemd:
         name: ypserv.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('ypserv' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('ypserv' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.11 | PATCH | Ensure print server services are not in use"
@@ -347,8 +358,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('cups' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('cups' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - "cups.socket"
@@ -381,8 +392,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('rpcbind' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('rpcbind' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - rpcbind.service
@@ -415,8 +426,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('rsync-daemon' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('rsync-daemon' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - 'rsyncd.socket'
@@ -448,8 +459,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: snmpd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('net-snmp' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('net-snmp' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.15 | PATCH | Ensure telnet server services are not in use"
@@ -479,8 +490,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: telnet.socket
-        enabled: false
-        state: stopped
+        enabled: "{{ ('telnet-server' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('telnet-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.16 | PATCH | Ensure tftp server services are not in use"
@@ -509,8 +520,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: "{{ item }}"
-        enabled: false
-        state: stopped
+        enabled: "{{ ('tftp-server' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('tftp-server' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - 'tftp.socket'
@@ -543,8 +554,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: squid.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('squid' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('squid' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.18 | PATCH | Ensure web server services are not in use"
@@ -583,8 +594,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: httpd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('httpd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('httpd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
     - name: "2.1.18 | PATCH | Ensure web server services are not in use | Mask nginx service"
@@ -594,8 +605,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: ngnix.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('nginx' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('nginx' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.19 | PATCH | Ensure xinetd services are not in use"
@@ -624,8 +635,8 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: xinetd.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('xinetd' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('xinetd' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
 
 - name: "2.1.20 | PATCH | Ensure X window server services are not in use"

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -105,6 +105,6 @@
       notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: bluetooth.service
-        enabled: false
-        state: stopped
+        enabled: "{{ ('bluez' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('bluez' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true

--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -32,6 +32,8 @@
         - rhel9cis_firewall == 'nftables'
       ansible.builtin.systemd:
         name: "{{ item }}"
+        enabled: "{{ ('firewalld' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('firewalld' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - firewalld
@@ -42,6 +44,8 @@
         - rhel9cis_firewall == 'firewalld'
       ansible.builtin.systemd:
         name: "{{ item }}"
+        enabled: "{{ ('nftables' in ansible_facts.packages) | ternary(false, omit) }}"
+        state: "{{ ('nftables' in ansible_facts.packages) | ternary('stopped', omit) }}"
         masked: true
       loop:
         - nftables

--- a/tasks/section_6/cis_6.2.2.1.x.yml
+++ b/tasks/section_6/cis_6.2.2.1.x.yml
@@ -72,8 +72,8 @@
     - NIST800-53R5_AU-12
   ansible.builtin.systemd:
     name: "{{ item }}"
-    state: stopped
-    enabled: false
+    enabled: "{{ ('systemd-journal-remote' in ansible_facts.packages) | ternary(false, omit) }}"
+    state: "{{ ('systemd-journal-remote' in ansible_facts.packages) | ternary('stopped', omit) }}"
     masked: true
   loop:
     - systemd-journal-remote.socket


### PR DESCRIPTION
**Overall Review of Changes:**
I added guardrails on enabled and state flags to systemd mask tasks to only disable and stop when the package is installed, o therwise just mask to prevent the service from ever starting should it get installed at a later time.  This allows hardening to proceed when the service doesn't exist but masking has been requested.  Otherwise the playbook run will fail at a step when the service which comes with the package doesn't already exist


NOTE that I found this method already done in the RHEL7 version of these mask tasks.

**Issue Fixes:**
[Please list (using linking) any open issues this PR addresses
this fixes #434

**Enhancements:**
This fixes the same issue for all the other mask tasks for which there are not bugs filed

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

example testing scenario: net-snmp is not installed:

```
[michael.hicks@ams101-0212-h04-lab ~]$ rpm -qa | grep net-snmpd
[michael.hicks@ams101-0212-h04-lab ~]$
[michael.hicks@ams101-0212-h04-lab ~]$ sudo systemctl status snmpd
Unit snmpd.service could not be found.
```
run CIS hardening scoped to this tag and see output note change

```
TASK [../roles/RHEL9-CIS : 2.1.14 | PATCH | Ensure snmp services are not in use | Mask service] *****************************************************
Wednesday 04 March 2026  11:08:30 -0800 (0:00:00.062)       0:00:20.098 *******
changed: [ams101-0212-h04-lab]
```

and the reset of the tasking continues rather than an error.  Final state on host is that the service is masked despite the package not being installed

```
[michael.hicks@ams101-0212-h04-lab ~]$ rpm -qa | grep net-snmpd
[michael.hicks@ams101-0212-h04-lab ~]$ sudo systemctl status snmpd
○ snmpd.service
     Loaded: masked (Reason: Unit snmpd.service is masked.)
     Active: inactive (dead)
```