### PR TITLE
Added always tag to ensure variable exists on CIS profile tag-based e…

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -259,6 +259,8 @@
 
 - name: "PRELIM | PATCH | sshd_config.d/50-redhat.conf exists"
   when: rhel9cis_rule_5_1_10 or rhel9cis_rule_5_1_11
+  tags:
+    - always
   ansible.builtin.stat:
     path: /etc/ssh/sshd_config.d/50-redhat.conf
   register: prelim_sshd_50_redhat_file


### PR DESCRIPTION
**Overall Review of Changes:**
When executing the role with tag filtering (-t level1-server,level1-workstation), the preliminary task that registers prelim_sshd_50_redhat_file was skipped because it had no tags.

Tasks 5.1.10 and 5.1.11 reference prelim_sshd_50_redhat_file.stat.exists, which caused the playbook to fail with an undefined variable error.

**Issue Fixes:**
Fixed issue for `prelim_sshd_50_redhat_file.stat_exists` not existing when executing the playbook using tags. 
**Error Message**
```
TASK [/home/frqadmin/Lockdown/RHEL9-CIS : 5.1.10 | PATCH | Ensure sshd DisableForwarding is enabled | override] ***
fatal: [rhel_host1]: FAILED! => {"msg": "The conditional check 'prelim_sshd_50_redhat_file.stat.exists' failed. The error was: error while evaluating conditional (prelim_sshd_50_redhat_file.stat.exists): 'prelim_sshd_50_redhat_file' is undefined. 'prelim_sshd_50_redhat_file' is undefined\n\nThe error appears to be in '/home/frqadmin/Lockdown/RHEL9-CIS/tasks/section_5/cis_5.1.x.yml': line 281, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: \"5.1.10 | PATCH | Ensure sshd DisableForwarding is enabled | override\"\n      ^ here\n"}
fatal: [rhel_host2]: FAILED! => {"msg": "The conditional check 'prelim_sshd_50_redhat_file.stat.exists' failed. The error was: error while evaluating conditional (prelim_sshd_50_redhat_file.stat.exists): 'prelim_sshd_50_redhat_file' is undefined. 'prelim_sshd_50_redhat_file' is undefined\n\nThe error appears to be in '/home/frqadmin/Lockdown/RHEL9-CIS/tasks/section_5/cis_5.1.x.yml': line 281, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: \"5.1.10 | PATCH | Ensure sshd DisableForwarding is enabled | override\"\n      ^ here\n"}

PLAY RECAP *********************************************************************
rhel_host1                 : ok=203  changed=17   unreachable=0    failed=1    skipped=131  rescued=0    ignored=0   
rhel_host2                 : ok=203  changed=17   unreachable=0    failed=1    skipped=131  rescued=0    ignored=0   
```

**How has this been tested?:**
Manually 

