### PR TITLE
Updated Jinja template to fix compliance issues for control 5.3.3.2.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1104,7 +1104,7 @@ rhel9cis_passwd_dictcheck_file: etc/security/pwquality.conf.d/50-pwdictcheck.con
 rhel9cis_passwd_dictcheck_value: 1
 
 # 5.3.3.2.7 - Ensure password quality is enforced for the root user
-rhel9cis_passwd_quality_enforce_file: etc/security/pwquality.conf.d/50-pwquality_enforce.conf  # pragma: allowlist secret
+rhel9cis_passwd_quality_enforce_file: etc/security/pwquality.conf.d/50-pwroot.conf  # pragma: allowlist secret
 rhel9cis_passwd_quality_enforce_value: 1
 rhel9cis_passwd_quality_enforce_root_value: enforce_for_root  # pragma: allowlist secret
 

--- a/tasks/section_5/cis_5.3.3.2.x.yml
+++ b/tasks/section_5/cis_5.3.3.2.x.yml
@@ -340,7 +340,7 @@
         - system
       notify: Authselect update
 
-- name: "5.3.3.2.7 | PATCH | Ensure password quality checking is enforced"
+- name: "5.3.3.2.7 | PATCH | Ensure password quality is enforced for the root user"
   when: rhel9cis_rule_5_3_3_2_7
   tags:
     - level1-server


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Updated the Ansible Configuration to correctly implement CIS Control 5.3.3.2.7 for RHEL9. As Nessus flags it as non compliant. 

**Issue Fixes:**
Fixes non-compliance for CIS Control 5.3.3.2.7 (Password quality enforcement for root).

**How has this been tested?:**
Tested on a live RHEL9 instance. Verified using the CIS-recommended audit command:
sudo grep -Psi -- '^\h*enforce_for_root\b' /etc/security/pwquality.conf /etc/security/pwquality.conf.d/*.conf
Output confirmed the setting is correctly applied in /etc/security/pwquality.conf.d/50-pwroot.conf

```
[frqadmin@localhost ~]$ sudo grep -Psi -- '^\h*enforce_for_root\b' /etc/security/pwquality.conf /etc/security/pwquality.conf.d/*.conf
/etc/security/pwquality.conf.d/50-pwroot.conf:enforce_for_root
[frqadmin@localhost ~]$
```

Please double check it, thanks! 
