### PR TITLE
Container correctness

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,6 +22,7 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp systemd"
+  when: not system_is_container
   vars:
     mount_point: '/tmp'
   ansible.builtin.systemd:
@@ -154,6 +155,7 @@
   listen: "Remount /boot/efi"
 
 - name: Reload sysctl
+  when: not system_is_container
   ansible.builtin.command: sysctl --system
   changed_when: true
 
@@ -177,6 +179,7 @@
     sysctl_set: true
 
 - name: Systemd restart tmp.mount
+  when: not system_is_container
   ansible.builtin.systemd:
     name: tmp.mount
     daemon_reload: true
@@ -198,49 +201,59 @@
     - Restart sshd
 
 - name: Restart firewalld
+  when: not system_is_container
   ansible.builtin.systemd:
     name: firewalld
     state: restarted
 
 - name: Restart sshd
+  when: not system_is_container
   ansible.builtin.systemd:
     name: sshd
     state: restarted
 
 - name: Restart postfix
+  when: not system_is_container
   ansible.builtin.systemd:
     name: postfix
     state: restarted
 
 - name: Reload dconf
+  when: not system_is_container
   ansible.builtin.command: dconf update
   changed_when: true
 
 - name: Grub2cfg
+  when: not system_is_container
   ansible.builtin.command: "grub2-mkconfig -o /boot/grub2/grub.cfg"
   changed_when: true
   ignore_errors: true  # noqa ignore-errors
 
 - name: Restart rsyslog
+  when: not system_is_container
   ansible.builtin.systemd:
     name: rsyslog
     state: restarted
 
 - name: Restart journald
+  when: not system_is_container
   ansible.builtin.systemd:
     name: systemd-journald
     state: restarted
 
 - name: Restart systemd_journal_upload
+  when: not system_is_container
   ansible.builtin.systemd:
     name: systemd-journal-upload
     state: restarted
 
 - name: Systemd daemon reload
+  when: not system_is_container
   ansible.builtin.systemd:
     daemon-reload: true
 
 - name: Authselect update
+  when: not system_is_container
   ansible.builtin.command: authselect apply-changes
   changed_when: true
 
@@ -260,12 +273,15 @@
   notify: Set reboot required
 
 - name: Stop auditd process
-  when: prelim_auditd_immutable_check is defined
+  when:
+    - prelim_auditd_immutable_check is defined
+    - not system_is_container
   ansible.builtin.command: systemctl kill auditd
   changed_when: true
   listen: Restart auditd
 
 - name: Start auditd process
+  when: not system_is_container
   ansible.builtin.systemd:
     name: auditd
     state: started

--- a/tasks/section_2/cis_2.4.x.yml
+++ b/tasks/section_2/cis_2.4.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "2.4.1.1 | PATCH | Ensure cron daemon is enabled and active"
-  when: rhel9cis_rule_2_4_1_1
+  when:
+    - rhel9cis_rule_2_4_1_1
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -44,6 +44,7 @@
 - name: "3.1.2 | PATCH | Ensure wireless interfaces are disabled"
   when:
     - rhel9cis_rule_3_1_2
+    - not system_is_container
     - prelim_wireless_adapters.rc == 0
   tags:
     - level1-server

--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -17,7 +17,9 @@
     state: present
 
 - name: "4.1.2 | PATCH | Ensure a single firewall configuration utility is in use"
-  when: rhel9cis_rule_4_1_2
+  when:
+    - rhel9cis_rule_4_1_2
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -67,6 +67,7 @@
   when:
     - rhel9cis_rule_6_1_2
     - not system_is_ec2
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_6/cis_6.2.1.x.yml
+++ b/tasks/section_6/cis_6.2.1.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "6.2.1.1 | PATCH | Ensure journald service is enabled and active"
-  when: rhel9cis_rule_6_2_1_1
+  when:
+    - rhel9cis_rule_6_2_1_1
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation
@@ -86,7 +88,9 @@
         - '^(\s*MaxFileSec\s*=.*)'
 
 - name: "6.2.1.4 | PATCH | Ensure only one logging system is in use"
-  when: rhel9cis_rule_6_2_1_4
+  when:
+    - rhel9cis_rule_6_2_1_4
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_6/cis_6.2.3.x.yml
+++ b/tasks/section_6/cis_6.2.3.x.yml
@@ -18,7 +18,9 @@
     state: present
 
 - name: "6.2.3.2 | PATCH | Ensure rsyslog service is enabled and active"
-  when: rhel9cis_rule_6_2_3_2
+  when:
+    - rhel9cis_rule_6_2_3_2
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_6/cis_6.3.1.x.yml
+++ b/tasks/section_6/cis_6.3.1.x.yml
@@ -26,7 +26,9 @@
         state: present
 
 - name: "6.3.1.2 | PATCH | Ensure auditing for processes that start prior to auditd is enabled"
-  when: rhel9cis_rule_6_3_1_2
+  when:
+    - rhel9cis_rule_6_3_1_2
+    - not system_is_container
   tags:
     - level2-server
     - level2-workstation
@@ -51,7 +53,9 @@
       changed_when: true
 
 - name: "6.3.1.3 | PATCH | Ensure audit_backlog_limit is sufficient"
-  when: rhel9cis_rule_6_3_1_3
+  when:
+    - rhel9cis_rule_6_3_1_3
+    - not system_is_container
   tags:
     - level2-server
     - level2-workstation
@@ -91,7 +95,9 @@
       changed_when: true
 
 - name: "6.3.1.4 | PATCH | Ensure auditd service is enabled and active"
-  when: rhel9cis_rule_6_3_1_4
+  when:
+    - rhel9cis_rule_6_3_1_4
+    - not system_is_container
   tags:
     - level2-server
     - level2-workstation

--- a/tasks/section_6/cis_6.3.4.x.yml
+++ b/tasks/section_6/cis_6.3.4.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "6.3.4.1 | PATCH | Ensure the audit log file directory mode is configured"
-  when: rhel9cis_rule_6_3_4_1
+  when:
+    - rhel9cis_rule_6_3_4_1
+    - not system_is_container
   tags:
     - level2-server
     - level2-workstation
@@ -22,6 +24,7 @@
     - rhel9cis_rule_6_3_4_2 or
       rhel9cis_rule_6_3_4_3 or
       rhel9cis_rule_6_3_4_4
+    - not system_is_container
   tags:
     - level2-server
     - level2-workstation

--- a/vars/is_container.yml
+++ b/vars/is_container.yml
@@ -151,4 +151,3 @@ rhel9cis_rule_6_3_4_7: false
 rhel9cis_rule_6_3_4_8: false
 rhel9cis_rule_6_3_4_9: false
 rhel9cis_rule_6_3_4_10: false
-

--- a/vars/is_container.yml
+++ b/vars/is_container.yml
@@ -86,3 +86,69 @@ rhel9cis_rule_4_2_2_3: false
 
 # Users/passwords/accounts
 rhel9cis_rule_5_5_2: false
+
+# authselect
+rhel9cis_allow_authselect_updates: false
+
+# 2.4.1.x cron not installed
+rhel9cis_rule_2_4_1_2: false
+rhel9cis_rule_2_4_1_3: false
+rhel9cis_rule_2_4_1_4: false
+rhel9cis_rule_2_4_1_5: false
+rhel9cis_rule_2_4_1_6: false
+rhel9cis_rule_2_4_1_7: false
+rhel9cis_rule_2_4_1_8: false
+
+# 6.2.1.x systemd not installed
+rhel9cis_rule_6_2_1_2: false
+rhel9cis_rule_6_2_1_3: false
+
+# 6.2.2.x journald config absent
+rhel9cis_rule_6_2_2_1_1: false
+rhel9cis_rule_6_2_2_1_2: false
+rhel9cis_rule_6_2_2_1_3: false
+rhel9cis_rule_6_2_2_1_4: false
+rhel9cis_rule_6_2_2_2: false
+rhel9cis_rule_6_2_2_3: false
+rhel9cis_rule_6_2_2_4: false
+
+# 6.3.1.1 auditd package install
+rhel9cis_rule_6_3_1_1: false
+
+# 6.3.2.x audit data retention
+rhel9cis_rule_6_3_2_1: false
+rhel9cis_rule_6_3_2_2: false
+rhel9cis_rule_6_3_2_3: false
+rhel9cis_rule_6_3_2_4: false
+
+# 6.3.3.x audit rules
+rhel9cis_rule_6_3_3_1: false
+rhel9cis_rule_6_3_3_2: false
+rhel9cis_rule_6_3_3_3: false
+rhel9cis_rule_6_3_3_4: false
+rhel9cis_rule_6_3_3_5: false
+rhel9cis_rule_6_3_3_6: false
+rhel9cis_rule_6_3_3_7: false
+rhel9cis_rule_6_3_3_8: false
+rhel9cis_rule_6_3_3_9: false
+rhel9cis_rule_6_3_3_10: false
+rhel9cis_rule_6_3_3_11: false
+rhel9cis_rule_6_3_3_12: false
+rhel9cis_rule_6_3_3_13: false
+rhel9cis_rule_6_3_3_14: false
+rhel9cis_rule_6_3_3_15: false
+rhel9cis_rule_6_3_3_16: false
+rhel9cis_rule_6_3_3_17: false
+rhel9cis_rule_6_3_3_18: false
+rhel9cis_rule_6_3_3_19: false
+rhel9cis_rule_6_3_3_20: false
+rhel9cis_rule_6_3_3_21: false
+
+# 6.3.4.5-10 audit log file perms
+rhel9cis_rule_6_3_4_5: false
+rhel9cis_rule_6_3_4_6: false
+rhel9cis_rule_6_3_4_7: false
+rhel9cis_rule_6_3_4_8: false
+rhel9cis_rule_6_3_4_9: false
+rhel9cis_rule_6_3_4_10: false
+


### PR DESCRIPTION
# Apply container guards to handlers and container-incompatible rules

## Summary

Extends container-awareness across the role so that running it inside a container (where `system_is_container` is true) no longer fails on host-only subsystems. This branch:

- Adds `when: not system_is_container` guards to handlers in `handlers/main.yml` that touch systemd units, kernel sysctls, or `authselect` (these have no working backend in most container runtimes and would otherwise abort the play on notify).
- Adds the same guard to a handful of patch tasks that try to enable/start services or configure host-level networking (`2.4.1.1`, `3.1.2`, `4.1.2`, `6.1.2`, `6.2.1.1`, `6.2.1.4`, `6.2.3.2`, `6.3.1.2`–`6.3.1.4`, `6.3.4.1`, and the `6.3.4.2/3/4` block).
- Expands `vars/is_container.yml` to disable additional rules that cannot be meaningfully applied inside a container.

## Rules disabled in containers (and why)

**Cron (2.4.1.2–2.4.1.8)** — Container images typically do not ship or run a cron daemon; permission/ownership checks on `/etc/cron*` and `crontab` files are irrelevant when the service isn't present.

**Journald / systemd logging (6.2.1.2, 6.2.1.3)** — These rules tune `systemd-journal-upload` and persistent journal storage. Containers usually don't run systemd or journald and instead emit logs to stdout/stderr for the runtime to capture.

**Journald configuration (6.2.2.1.1–6.2.2.1.4, 6.2.2.2, 6.2.2.3, 6.2.2.4)** — Same rationale: configuring `journald.conf` (compression, forwarding, persistent storage, file rotation) requires journald, which is not the logging mechanism inside a container.

**auditd package install (6.3.1.1)** — `auditd` requires kernel audit subsystem access; containers share the host kernel and cannot install or run their own auditd usefully. Audit policy is the host's responsibility.

**Audit data retention (6.3.2.1–6.3.2.4)** — These configure `auditd.conf` (max log size, retention, disk-full action). Without auditd running, there is nothing to retain.

**Audit rules (6.3.3.1–6.3.3.21)** — These load rules into the kernel audit subsystem via `auditctl`/`audit.rules`. The kernel audit interface is namespaced to the host; loading rules from inside a container is not supported and silently does nothing or errors.

**Audit log file permissions (6.3.4.5–6.3.4.10)** — These set ownership/mode on `/var/log/audit/*` and audit tooling binaries. With no auditd writing logs and audit binaries provided by the host image, enforcing these inside the container is meaningless.

**`rhel9cis_allow_authselect_updates: false`** — `authselect apply-changes` requires the host PAM/nsswitch stack and writes to system-managed profiles; in a container this either fails or alters files that will be discarded with the layer.

## Test plan

I've run this against rockylinux/rockylinux:9.4 with "--skip-tags manual" and I no longer need to override these rules. 
